### PR TITLE
chore: add recipes and examples skills, cross-reference SDKs, regen from latest specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ For more information, check out:
 
 This repository contains skills for building with Deepgram's speech-to-text, text-to-speech, voice agent, and audio intelligence APIs. Skills are agent-agnostic — plain markdown that any AI coding tool can consume.
 
+Deepgram ships two actively maintained, industry-leading speech-to-text model families:
+
+- **Nova** (`/v1/listen`) — general-purpose transcription with a rich intelligence feature set (diarize, summarize, sentiment, topics, intents). Use for captions, subtitles, batch, and general live streaming.
+- **Flux** (`/v2/listen`, `model=flux-general-en`) — conversational STT with built-in turn detection. Use for voice agents and interactive assistants. See the `api` skill for the full Nova vs Flux decision guide.
+
 Some skills are hand-written, others are generated from Deepgram's [OpenAPI](https://dpgr.am/openapi.yml) and [AsyncAPI](https://dpgr.am/asyncapi.yml) specs.
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -26,7 +26,29 @@ Some skills are hand-written, others are generated from Deepgram's [OpenAPI](htt
 | [api](./skills/api) | Full API reference for all Deepgram REST and WebSocket APIs, generated from OpenAPI and AsyncAPI specs |
 | [docs](./skills/docs) | Find the right Deepgram documentation for any task |
 | [starters](./skills/starters) | Clone a ready-to-run demo app in your language and start building — 13 frameworks, 7 features |
+| [recipes](./skills/recipes) | Focused runnable recipes for one feature × one language — minimal working code (< 50 lines) |
+| [examples](./skills/examples) | Integration examples with third-party platforms (Twilio, LiveKit, LangChain, Vercel AI SDK, etc.) |
 | [setup-mcp](./skills/setup-mcp) | Set up the Deepgram MCP server for querying docs directly from your AI coding tool |
+
+## SDK-Specific Skills
+
+Each Deepgram SDK repository publishes its own set of language-idiomatic skills under `.agents/skills/`:
+
+```bash
+npx skills add deepgram/deepgram-python-sdk     # Python
+npx skills add deepgram/deepgram-js-sdk         # JavaScript / TypeScript
+npx skills add deepgram/deepgram-java-sdk       # Java
+npx skills add deepgram/deepgram-go-sdk         # Go
+npx skills add deepgram/deepgram-rust-sdk       # Rust
+npx skills add deepgram/deepgram-swift-sdk      # Swift
+npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
+npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
+npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
+```
+
+Each SDK ships 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) plus a maintainer skill.
+
+This `deepgram/skills` repo covers product contracts (API reference, docs, starters, recipes, integrations, MCP). The SDK repos cover language-specific usage.
 
 # Install
 

--- a/scripts/generate-skills.ts
+++ b/scripts/generate-skills.ts
@@ -90,6 +90,25 @@ interface EndpointInfo {
   responses: any;
 }
 
+function normalizeTag(rawTag: string | undefined, path: string): string {
+  const t = (rawTag ?? "").toLowerCase();
+  const p = path.toLowerCase();
+  if (t.includes("listen") || p.includes("/listen")) return "Listen";
+  if (t.includes("speak") || p.includes("/speak")) return "Speak";
+  if (t.includes("voiceagent") || p.includes("/agent")) return "Agent";
+  if (t.includes("agent")) return "Agent";
+  if (t.includes("read") || p.includes("/read")) return "Read";
+  if (t.includes("selfhost") || t.includes("self-host") || t.includes("onprem") || p.includes("/selfhosted") || p.includes("/onprem")) return "Self-Hosted";
+  if (t.includes("models") || p.match(/\/models(\/|$)/)) return "Models";
+  if (t.includes("auth") || p.includes("/auth/")) return "Auth";
+  if (
+    t.includes("manage") || t.includes("projects") || t.includes("keys") ||
+    t.includes("members") || t.includes("invites") || t.includes("usage") ||
+    t.includes("billing") || t.includes("scopes") || p.includes("/projects")
+  ) return "Projects";
+  return "Other";
+}
+
 function groupOpenApiEndpoints(spec: any): Map<string, ApiGroup> {
   const groups = new Map<string, ApiGroup>();
   const paths = spec.paths ?? {};
@@ -99,11 +118,7 @@ function groupOpenApiEndpoints(spec: any): Map<string, ApiGroup> {
       const op = pathObj[method];
       if (!op) continue;
 
-      // Use the first meaningful tag as group key
-      const tag =
-        op.tags?.find((t: string) =>
-          ["Listen", "Speak", "Read", "Agent", "Models", "Projects", "Auth"].includes(t)
-        ) ?? op.tags?.[0] ?? "Other";
+      const tag = normalizeTag(op.tags?.[0], path);
 
       if (!groups.has(tag)) {
         groups.set(tag, { tag, endpoints: [] });
@@ -206,59 +221,77 @@ interface MessageInfo {
   payload?: any;
 }
 
+function messageName(refPath: string | undefined, resolved: any): string {
+  if (resolved?.name) return resolved.name;
+  if (resolved?.title) return resolved.title;
+  if (refPath) {
+    const last = refPath.split("/").pop() ?? "";
+    return last
+      .replace(/Message$|Event$/, "")
+      .replace(/^.*-\d+-/, "");
+  }
+  return "Unknown";
+}
+
+function extractMessages(spec: any, op: any): MessageInfo[] {
+  if (!op?.message) return [];
+  const variants = op.message.oneOf ?? [op.message];
+  const out: MessageInfo[] = [];
+  for (const v of variants) {
+    const refPath = v?.$ref;
+    const resolved = resolve(spec, v);
+    out.push({
+      name: messageName(refPath, resolved),
+      description: resolved?.description ?? op.description ?? op.summary ?? "",
+      payload: resolved?.payload ? resolve(spec, resolved.payload) : undefined,
+    });
+  }
+  return out;
+}
+
 function extractChannels(spec: any): ChannelInfo[] {
   const channels: ChannelInfo[] = [];
   const rawChannels = spec.channels ?? {};
-  const operations = spec.operations ?? {};
 
   for (const [name, ch] of Object.entries(rawChannels) as [string, any][]) {
-    const resolved = resolve(spec, ch);
-    if (!resolved.address) continue; // skip message-only entries
+    if (!ch || typeof ch !== "object") continue;
 
-    const serverRef = ch.servers?.[0]?.$ref;
-    const server = serverRef
-      ? resolveRef(spec, serverRef)
-      : ch.servers?.[0];
+    const address = ch.address ?? name;
 
-    const sendMsgs: MessageInfo[] = [];
-    const recvMsgs: MessageInfo[] = [];
+    const serverHost = spec.servers?.Production?.url
+      ?? spec.servers?.production?.url
+      ?? spec.servers?.[Object.keys(spec.servers ?? {})[0]]?.url;
 
-    // Classify messages using operations
-    for (const [opName, op] of Object.entries(operations) as [string, any][]) {
-      const opChannel = op.channel?.$ref;
-      if (!opChannel?.endsWith(`/${name}`)) continue;
+    const queryParams = ch.bindings?.ws?.query;
 
-      const msgs = (op.messages ?? []).map((m: any) => {
-        // Extract a readable name from the $ref path or resolved content
-        const refName = m.$ref
-          ? m.$ref.split("/").pop()?.replace(/Message$|Event$/, "")
-          : undefined;
-        const resolved = resolve(spec, m);
-        return {
-          name: resolved.name ?? resolved.title ?? refName ?? opName,
-          description: op.description ?? resolved.description ?? "",
-          payload: resolved.payload ? resolve(spec, resolved.payload) : undefined,
-        };
-      });
-
-      if (op.action === "send") sendMsgs.push(...msgs);
-      else if (op.action === "receive") recvMsgs.push(...msgs);
-    }
+    const publishMsgs = extractMessages(spec, ch.publish);
+    const subscribeMsgs = extractMessages(spec, ch.subscribe);
 
     channels.push({
       name,
-      address: resolved.address,
-      description: resolved.description ?? "",
-      server: server ? `wss://${server.host}` : undefined,
-      queryParams: resolved.bindings?.ws?.query
-        ? resolve(spec, resolved.bindings.ws.query)
-        : undefined,
-      sendMessages: sendMsgs,
-      receiveMessages: recvMsgs,
+      address,
+      description: ch.description ?? ch.publish?.description ?? ch.subscribe?.description ?? "",
+      server: resolveChannelServer(name, serverHost),
+      queryParams: queryParams ? resolve(spec, queryParams) : undefined,
+      sendMessages: subscribeMsgs,
+      receiveMessages: publishMsgs,
     });
   }
 
   return channels;
+}
+
+// Voice Agent runs on a dedicated server (`wss://agent.deepgram.com`). The
+// AsyncAPI spec declares only one global server, so per-channel servers are
+// applied here until the spec encodes them natively.
+function resolveChannelServer(channelName: string, specServer: string | undefined): string | undefined {
+  if (channelName.toLowerCase().includes("/agent")) {
+    return "wss://agent.deepgram.com";
+  }
+  if (!specServer) return undefined;
+  return specServer.startsWith("ws://") || specServer.startsWith("wss://")
+    ? specServer.replace(/\/$/, "")
+    : `wss://${specServer.replace(/^https?:\/\//, "").replace(/\/$/, "")}`;
 }
 
 function renderChannel(ch: ChannelInfo): string {
@@ -304,9 +337,10 @@ function renderChannel(ch: ChannelInfo): string {
 // ---------------------------------------------------------------------------
 
 function channelDomain(name: string): string {
-  if (name.startsWith("Listen")) return "Listen";
-  if (name.startsWith("Speak")) return "Speak";
-  if (name.startsWith("Agent")) return "Agent";
+  const n = name.toLowerCase();
+  if (n.includes("/listen") || n.startsWith("listen")) return "Listen";
+  if (n.includes("/speak") || n.startsWith("speak")) return "Speak";
+  if (n.includes("/agent") || n.startsWith("agent")) return "Agent";
   return "Other";
 }
 

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -123,6 +123,36 @@ Analyze text or audio for insights?
 
 12. **JWT TTL applies only to the initial handshake.** Tokens default to 30 seconds. Once the WebSocket connection is established, the token expiring does not close it — tokens are only needed for the upgrade request.
 
+## SDK-Specific Skills
+
+This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) and a maintainer skill.
+
+```bash
+# Install all skills from a specific SDK
+npx skills add deepgram/deepgram-python-sdk     # Python
+npx skills add deepgram/deepgram-js-sdk         # JavaScript / TypeScript
+npx skills add deepgram/deepgram-java-sdk       # Java
+npx skills add deepgram/deepgram-go-sdk         # Go
+npx skills add deepgram/deepgram-rust-sdk       # Rust
+npx skills add deepgram/deepgram-swift-sdk      # Swift
+npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
+npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
+npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
+
+# Or install a specific product skill from one SDK
+npx skills add deepgram/deepgram-python-sdk --skill using-speech-to-text
+```
+
+## Related Deepgram skills
+
+| Skill | Purpose |
+|---|---|
+| `recipes` | Minimal runnable snippets per feature per language |
+| `examples` | Full integration examples with third-party platforms (Twilio, LiveKit, etc.) |
+| `starters` | Runnable starter apps (framework × feature matrix) |
+| `docs` | Navigate Deepgram documentation |
+| `setup-mcp` | Install the Deepgram MCP server |
+
 ## Documentation
 
 - [API Reference](https://developers.deepgram.com/reference/deepgram-api-overview)

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -31,11 +31,11 @@ Base servers:
                    │       api.deepgram.com        │
                    └──────────────────────────────┘
                                 │
-         ┌──────────────────────┼──────────────────────┐
-         ▼                      ▼                      ▼
-    /v1/listen              /v1/speak              /v1/read
-  (audio → text)          (text → audio)        (intelligence)
-  REST or WebSocket        REST or WebSocket       REST only
+  ┌──────────────┬──────────────┼──────────────┬──────────────┐
+  ▼              ▼              ▼              ▼              ▼
+/v1/listen   /v2/listen     /v1/speak      /v1/read    /v1/projects/*
+ Nova — ASR   Flux — conv.   TTS            Text AI     Management
+REST or WSS   WSS only       REST or WSS    REST only   REST only
 
                    ┌──────────────────────────────┐
                    │      agent.deepgram.com       │
@@ -51,28 +51,64 @@ Base servers:
 ## Which API Should I Use?
 
 ```
-Audio → text?
-├─ Pre-recorded file    →  REST  POST /v1/listen
-└─ Live stream          →  WebSocket wss://api.deepgram.com/v1/listen
+Audio → text (transcription)?
+├─ General-purpose transcription (captions, batch, call logs, live streams with custom turn logic)
+│  └─ Nova models via /v1/listen
+│     ├─ Pre-recorded file    →  REST  POST https://api.deepgram.com/v1/listen?model=nova-3
+│     └─ Live stream          →  WSS   wss://api.deepgram.com/v1/listen?model=nova-3
+│
+└─ Conversational audio / voice-agent-style turn detection
+   └─ Flux models via /v2/listen
+      └─ Live stream          →  WSS   wss://api.deepgram.com/v2/listen?model=flux-general-en
 
 Text → audio?
-├─ One-shot             →  REST  POST /v1/speak
-└─ Low-latency stream   →  WebSocket wss://api.deepgram.com/v1/speak
+├─ One-shot                   →  REST POST /v1/speak
+└─ Low-latency stream         →  WSS  wss://api.deepgram.com/v1/speak
 
 Full conversational voice agent (audio in, audio out)?
-└─ WebSocket wss://agent.deepgram.com/v1/agent/converse
+└─ WSS wss://agent.deepgram.com/v1/agent/converse
    Deepgram handles STT + your configured LLM + TTS internally
 
-Analyze text or audio for insights?
+Analyze text for insights?
 └─ REST POST /v1/read
    (summaries, sentiment, topics, intents)
 ```
+
+## Speech-to-Text: Nova (`/v1/listen`) vs Flux (`/v2/listen`)
+
+Both model families are actively maintained and industry-leading. They solve different problems — pick the one that matches your use case.
+
+| | Nova (`/v1/listen`) | Flux (`/v2/listen`) |
+|---|---|---|
+| Endpoint | `/v1/listen` | `/v2/listen` |
+| Available models | `nova-3`, `nova-2`, `nova`, `enhanced`, `base` | `flux-general-en` |
+| Best for | General transcription — captions, subtitles, call logs, batch | Conversational audio — voice agents, interactive assistants, turn-taking UIs |
+| Output | Continuous transcript stream | Structured turn events + transcripts (built-in turn state machine) |
+| Turn detection | Manual (`utterance_end_ms`, VAD events) | Built-in (EOT, eager-EOT, turn_index) |
+| Transports | REST + WebSocket | WebSocket only |
+| Intelligence overlays | Yes — `summarize`, `sentiment`, `topics`, `intents`, `diarize`, `redact`, etc. | No — smaller focused param set; no `smart_format` / `diarize` / `punctuate` |
+| Mid-session reconfig | No (reconnect to change) | Yes (`Configure` message updates EOT thresholds + keyterms live) |
+
+**Pick Nova (`/v1/listen`, `model=nova-3`) when:**
+- Generating captions, subtitles, or transcripts for recorded media
+- Running batch transcription over files (REST)
+- You need analytics overlays (`summarize`, `sentiment`, `topics`, `intents`, `diarize`, `redact`)
+- You want WebSocket streaming with your own turn-detection logic
+
+**Pick Flux (`/v2/listen`, `model=flux-general-en`) when:**
+- Building an interactive voice agent or assistant
+- You want end-of-turn detection handled for you
+- You need low-latency turn signals and barge-in support
+- You want to update EOT thresholds or keyterms mid-session without reconnecting
+
+Migrating from Nova 3 to Flux? See the official [Nova 3 → Flux migration guide](https://developers.deepgram.com/docs/flux/nova-3-migration).
 
 ## API Domains
 
 | Domain | REST | WebSocket | Reference |
 |--------|------|-----------|-----------|
-| Listen (STT) | `POST /v1/listen` | `wss://api.deepgram.com/v1/listen` | [listen.md](references/listen.md) |
+| Listen v1 — STT, Nova models | `POST /v1/listen` | `wss://api.deepgram.com/v1/listen` | [listen.md](references/listen.md) |
+| Listen v2 — STT, Flux (conversational) | — | `wss://api.deepgram.com/v2/listen` | [listen.md](references/listen.md) |
 | Speak (TTS) | `POST /v1/speak` | `wss://api.deepgram.com/v1/speak` | [speak.md](references/speak.md) |
 | Voice Agent | `GET /v1/agent/settings/think/models` | `wss://agent.deepgram.com/v1/agent/converse` | [agent.md](references/agent.md) |
 | Read (Intelligence) | `POST /v1/read` | — | [read.md](references/read.md) |

--- a/skills/api/references/agent.md
+++ b/skills/api/references/agent.md
@@ -27,7 +27,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### GET `/v1/agent/settings/think/models`
-> Server: `https://agent.deepgram.com`
 
 List Agent Think Models
 
@@ -36,6 +35,144 @@ Retrieves the available think models that can be used for AI agent processing
 #### Responses
 
 **200**: List of available think models
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/agents`
+
+List Agent Configurations
+
+Returns all agent configurations for the specified project. Configurations are returned in their uninterpolated form—template variable placeholders appear as-is rather than with their substituted values.
+
+#### Responses
+
+**200**: A list of agent configurations
+**400**: Invalid Request
+
+### POST `/v1/projects/{project_id}/agents`
+
+Create an Agent Configuration
+
+Creates a new reusable agent configuration. The `config` field must be a valid JSON string representing the `agent` block of a Settings message. The returned `agent_id` can be passed in place of the full `agent` object in future Settings messages.
+
+#### Request Body
+
+**application/json**
+
+- `config` string **(required)** — A valid JSON string representing the agent block of a Settings message
+- `metadata` object — A map of arbitrary key-value pairs for labeling or organizing the agent configuration
+- `api_version` integer (default: `1`) — API version. Defaults to 1
+
+#### Responses
+
+**200**: Agent configuration created successfully
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/agents/{agent_id}`
+
+Get an Agent Configuration
+
+Returns the specified agent configuration in its uninterpolated form
+
+#### Responses
+
+**200**: An agent configuration
+**400**: Invalid Request
+
+### PUT `/v1/projects/{project_id}/agents/{agent_id}`
+
+Update Agent Metadata
+
+Updates the metadata associated with an agent configuration. The config itself is immutable—to change the configuration, delete the existing agent and create a new one.
+
+#### Request Body
+
+**application/json**
+
+- `metadata` object **(required)** — A map of string key-value pairs to associate with this agent configuration
+
+#### Responses
+
+**200**: Agent configuration updated
+**400**: Invalid Request
+
+### DELETE `/v1/projects/{project_id}/agents/{agent_id}`
+
+Delete an Agent Configuration
+
+Deletes the specified agent configuration. Deleting an agent configuration can cause a production outage if your service references this agent UUID. Migrate all active sessions to a new configuration before deleting.
+
+#### Responses
+
+**200**: Agent configuration deleted
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/agent-variables`
+
+List Agent Variables
+
+Returns all template variables for the specified project
+
+#### Responses
+
+**200**: A list of agent variables
+**400**: Invalid Request
+
+### POST `/v1/projects/{project_id}/agent-variables`
+
+Create an Agent Variable
+
+Creates a new template variable. Variables follow the `DG_<VARIABLE_NAME>` naming format and can substitute any JSON value in an agent configuration.
+
+#### Request Body
+
+**application/json**
+
+- `key` string **(required)** — The variable name, following the DG_<VARIABLE_NAME> format
+- `value` any **(required)** — The value to substitute. Can be any valid JSON type (string, number, boolean, object, or array)
+- `api_version` integer (default: `1`) — API version. Defaults to 1
+
+#### Responses
+
+**200**: Agent variable created successfully
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/agent-variables/{variable_id}`
+
+Get an Agent Variable
+
+Returns the specified template variable
+
+#### Responses
+
+**200**: An agent variable
+**400**: Invalid Request
+
+### PATCH `/v1/projects/{project_id}/agent-variables/{variable_id}`
+
+Update an Agent Variable
+
+Updates the value of an existing template variable
+
+#### Request Body
+
+**application/json**
+
+- `value` any **(required)** — The new value to substitute
+
+#### Responses
+
+**200**: Agent variable updated
+**400**: Invalid Request
+
+### DELETE `/v1/projects/{project_id}/agent-variables/{variable_id}`
+
+Delete an Agent Variable
+
+Deletes the specified template variable
+
+#### Responses
+
+**200**: Agent variable deleted
 **400**: Invalid Request
 
 ## WebSocket API
@@ -47,139 +184,54 @@ Build a conversational voice agent using Deepgram's Voice Agent WebSocket
 
 #### Client → Server Messages
 
-**AgentV1SettingsMessage** — Send settings configuration to Deepgram's Voice Agent API
+**AgentV1Settings** — Client messages
 
-  - `type` `Settings` **(required)**
-  - `tags` string[] — Tags to associate with the request
-  - `experimental` boolean (default: `false`) — To enable experimental features
-  - `flags` { history: boolean }
-  - `mip_opt_out` boolean (default: `false`) — To opt out of Deepgram Model Improvement Program
-  - `audio` { input: { encoding: `linear16` | `linear32` | `flac` | `alaw` | `mulaw` | `amr-nb` | `amr-wb` | `opus` | `ogg-opus` | `speex` | `g729`, sample_rate: number }, output: { encoding: `linear16` | `mulaw` | `alaw`, sample_rate: number, bitrate: number, container: string } } **(required)**
-  - `agent` { language: string, context: { messages: object | object[] }, listen: { provider: object | object }, think: { provider: object | object | object | object | object, endpoint: object, functions: object[], prompt: string, context_length: `max` | number } | { provider: object | object | object | object | object, endpoint: object, functions: object[], prompt: string, context_length: `max` | number }[], speak: { provider: object | object | object | object | object, endpoint: object } | { provider: object | object | object | object | object, endpoint: object }[], greeting: string } **(required)**
+**AgentV1UpdateSpeak** — Client messages
 
-**AgentV1UpdateSpeak** — Send update speak to Deepgram's Voice Agent API
+**AgentV1InjectUser** — Client messages
 
-  - `type` `UpdateSpeak` **(required)** — Message type identifier for updating the speak model
-  - `speak` { provider: { type: `deepgram`, version: `v1`, model: `aura-asteria-en` | `aura-luna-en` | `aura-stella-en` | `aura-athena-en` | `aura-hera-en` | `aura-orion-en` | `aura-arcas-en` | `aura-perseus-en` | `aura-angus-en` | `aura-orpheus-en` | `aura-helios-en` | `aura-zeus-en` | `aura-2-amalthea-en` | `aura-2-andromeda-en` | `aura-2-apollo-en` | `aura-2-arcas-en` | `aura-2-aries-en` | `aura-2-asteria-en` | `aura-2-athena-en` | `aura-2-atlas-en` | `aura-2-aurora-en` | `aura-2-callista-en` | `aura-2-cora-en` | `aura-2-cordelia-en` | `aura-2-delia-en` | `aura-2-draco-en` | `aura-2-electra-en` | `aura-2-harmonia-en` | `aura-2-helena-en` | `aura-2-hera-en` | `aura-2-hermes-en` | `aura-2-hyperion-en` | `aura-2-iris-en` | `aura-2-janus-en` | `aura-2-juno-en` | `aura-2-jupiter-en` | `aura-2-luna-en` | `aura-2-mars-en` | `aura-2-minerva-en` | `aura-2-neptune-en` | `aura-2-odysseus-en` | `aura-2-ophelia-en` | `aura-2-orion-en` | `aura-2-orpheus-en` | `aura-2-pandora-en` | `aura-2-phoebe-en` | `aura-2-pluto-en` | `aura-2-saturn-en` | `aura-2-selene-en` | `aura-2-thalia-en` | `aura-2-theia-en` | `aura-2-vesta-en` | `aura-2-zeus-en` | `aura-2-sirio-es` | `aura-2-nestor-es` | `aura-2-carina-es` | `aura-2-celeste-es` | `aura-2-alvaro-es` | `aura-2-diana-es` | `aura-2-aquila-es` | `aura-2-selena-es` | `aura-2-estrella-es` | `aura-2-javier-es` } | { type: `eleven_labs`, version: `v1`, model_id: `eleven_turbo_v2_5` | `eleven_monolingual_v1` | `eleven_multilingual_v2`, language: string, language_code: string } | { type: `cartesia`, version: `2025-03-17`, model_id: `sonic-2` | `sonic-multilingual`, voice: object, language: string } | { type: `open_ai`, version: `v1`, model: `tts-1` | `tts-1-hd`, voice: `alloy` | `echo` | `fable` | `onyx` | `nova` | `shimmer` } | { type: `aws_polly`, voice: `Matthew` | `Joanna` | `Amy` | `Emma` | `Brian` | `Arthur` | `Aria` | `Ayanda`, language: string, language_code: string, engine: `generative` | `long-form` | `standard` | `neural`, credentials: object }, endpoint: { url: string, headers: object } } **(required)**
+**AgentV1InjectAgent** — Client messages
 
-**AgentV1InjectUser** — Send inject user message to Deepgram's Voice Agent API
+**AgentV1SendFunctionCallResponse** — Client messages
 
-  - `type` `InjectUserMessage` **(required)** — Message type identifier for injecting a user message
-  - `content` string **(required)** — The specific phrase or statement the agent should respond to
+**AgentV1KeepAlive** — Client messages
 
-**AgentV1InjectAgent** — Send inject agent message to Deepgram's Voice Agent API
+**AgentV1UpdatePrompt** — Client messages
 
-  - `type` `InjectAgentMessage` **(required)** — Message type identifier for injecting an agent message
-  - `message` string **(required)** — The statement that the agent should say
+**AgentV1UpdateThink** — Client messages
 
-**AgentV1SendFunctionCallResponse** — Send a function call response from the client to the server after
-executing a client-side function call. This is used when the server
-requests execution of a function marked with `client_side: true`.
-
-
-  - `type` `FunctionCallResponse` **(required)** — Message type identifier for function call responses
-  - `id` string — The unique identifier for the function call.
-
-• **Required for client responses**: Should match the id from
-  the corresponding `FunctionCallRequest`
-• **Optional for server responses**: Server may omit when responding
-  to internal function executions
-
-  - `name` string **(required)** — The name of the function being called
-  - `content` string **(required)** — The content or result of the function call
-
-**AgentV1KeepAlive** — Send keep alive to Deepgram's Voice Agent API
-
-  - `type` `KeepAlive` **(required)** — Message type identifier
-
-**AgentV1UpdatePrompt** — Send a prompt update to Deepgram's Voice Agent API
-
-  - `type` `UpdatePrompt` **(required)** — Message type identifier for prompt update request
-  - `prompt` string **(required)** — The new system prompt to be used by the agent
-
-**AgentV1MediaMessage** — Send raw binary audio data to Deepgram's Voice Agent API for processing
+**AgentV1Media** — Client messages
 
 #### Server → Client Messages
 
-**AgentV1ReceiveFunctionCallResponse** — Receive a function call response from the server after the server
-has executed a server-side function call internally. This occurs
-when functions are marked with `client_side: false`.
+**AgentV1ReceiveFunctionCallResponse** — Server messages
 
+**AgentV1PromptUpdated** — Server messages
 
-  - `type` `FunctionCallResponse` **(required)** — Message type identifier for function call responses
-  - `id` string — The unique identifier for the function call.
+**AgentV1SpeakUpdated** — Server messages
 
-• **Required for client responses**: Should match the id from
-  the corresponding `FunctionCallRequest`
-• **Optional for server responses**: Server may omit when responding
-  to internal function executions
+**AgentV1ThinkUpdated** — Server messages
 
-  - `name` string **(required)** — The name of the function being called
-  - `content` string **(required)** — The content or result of the function call
+**AgentV1InjectionRefused** — Server messages
 
-**AgentV1PromptUpdatedEvent** — Receive prompt update from Deepgram's Voice Agent API
+**AgentV1Welcome** — Server messages
 
-  - `type` `PromptUpdated` **(required)** — Message type identifier for prompt update confirmation
+**AgentV1SettingsApplied** — Server messages
 
-**AgentV1SpeakUpdatedEvent** — Receive speak update from Deepgram's Voice Agent API
+**AgentV1ConversationText** — Server messages
 
-  - `type` `SpeakUpdated` **(required)** — Message type identifier for speak update confirmation
+**AgentV1UserStartedSpeaking** — Server messages
 
-**AgentV1InjectionRefused** — Receive injection refused message from Deepgram's Voice Agent API
+**AgentV1AgentThinking** — Server messages
 
-  - `type` `InjectionRefused` **(required)** — Message type identifier for injection refused
-  - `message` string **(required)** — Details about why the injection was refused
+**AgentV1FunctionCallRequest** — Server messages
 
-**AgentV1Welcome** — Receive welcome message from Deepgram's Voice Agent API
+**AgentV1AgentStartedSpeaking** — Server messages
 
-  - `type` `Welcome` **(required)** — Message type identifier for welcome message
-  - `request_id` string **(required)** — Unique identifier for the request
+**AgentV1AgentAudioDone** — Server messages
 
-**AgentV1SettingsApplied** — Receive settings applied message from Deepgram's Voice Agent API
+**AgentV1Error** — Server messages
 
-  - `type` `SettingsApplied` **(required)** — Message type identifier for settings applied confirmation
+**AgentV1Warning** — Server messages
 
-**AgentV1ConversationText** — Receive conversation text from Deepgram's Voice Agent API
-
-  - `type` `ConversationText` **(required)** — Message type identifier for conversation text
-  - `role` `user` | `assistant` **(required)** — Identifies who spoke the statement
-  - `content` string **(required)** — The actual statement that was spoken
-
-**AgentV1UserStartedSpeaking** — Receive user started speaking message from Deepgram's Voice Agent API
-
-  - `type` `UserStartedSpeaking` **(required)** — Message type identifier indicating that the user has begun speaking
-
-**AgentV1AgentThinking** — Receive agent thinking message from Deepgram's Voice Agent API
-
-  - `type` `AgentThinking` **(required)** — Message type identifier for agent thinking
-  - `content` string **(required)** — The text of the agent's thought process
-
-**AgentV1FunctionCallRequestEvent** — Receive function call request from Deepgram's Voice Agent API
-
-  - `type` `FunctionCallRequest` **(required)** — Message type identifier for function call requests
-  - `functions` { id: string, name: string, arguments: string, client_side: boolean }[] **(required)** — Array of functions to be called
-
-**AgentV1AgentStartedSpeakingEvent** — Receive agent started speaking message from Deepgram's Voice Agent API
-
-  - `type` `AgentStartedSpeaking` **(required)** — Message type identifier for agent started speaking
-  - `total_latency` number **(required)** — Seconds from receiving the user's utterance to producing the agent's reply
-  - `tts_latency` number **(required)** — The portion of total latency attributable to text-to-speech
-  - `ttt_latency` number **(required)** — The portion of total latency attributable to text-to-text (usually an LLM)
-
-**AgentV1AgentAudioDoneEvent** — Receive agent audio done message from Deepgram's Voice Agent API
-
-  - `type` `AgentAudioDone` **(required)** — Message type identifier indicating the agent has finished sending audio
-
-**AgentV1ErrorEvent** — Receive error response from Deepgram's Voice Agent API
-
-  - `type` `Error` **(required)** — Message type identifier for error responses
-  - `description` string **(required)** — A description of what went wrong
-  - `code` string **(required)** — Error code identifying the type of error
-
-**AgentV1WarningEvent** — Receive warning messages from Deepgram's Voice Agent API
-
-  - `type` `Warning` **(required)** — Message type identifier for warnings
-  - `description` string **(required)** — Description of the warning
-  - `code` string **(required)** — Warning code identifier
-
-**AgentV1AudioChunkEvent** — Receive raw binary audio data generated by Deepgram's Voice Agent API
+**AgentV1Audio** — Server messages

--- a/skills/api/references/auth.md
+++ b/skills/api/references/auth.md
@@ -26,7 +26,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### POST `/v1/auth/grant`
-> Server: `https://api.deepgram.com`
 
 Token-based Authentication
 

--- a/skills/api/references/listen.md
+++ b/skills/api/references/listen.md
@@ -27,7 +27,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### POST `/v1/listen`
-> Server: `https://api.deepgram.com`
 
 Transcribe and analyze pre-recorded audio and video
 
@@ -57,19 +56,19 @@ Transcribe audio and video using Deepgram's speech-to-text REST API
 - `keywords` string | string[] — Keywords can boost or suppress specialized terminology and brands
 - `language` string (default: `en`) — The [BCP-47 language tag](https://tools.ietf.org/html/bcp47) that hints at the primary spoken language. Depending on the Model and API endpoint you choose only certain languages are available
 - `measurements` boolean (default: `false`) — Spoken measurements will be converted to their corresponding abbreviations
-- `model` `nova-3` | `nova-3-general` | `nova-3-medical` | `nova-2` | `nova-2-general` | `nova-2-meeting` | `nova-2-finance` | `nova-2-conversationalai` | `nova-2-voicemail` | `nova-2-video` | `nova-2-medical` | `nova-2-drivethru` | `nova-2-automotive` | `nova` | `nova-general` | `nova-phonecall` | `nova-medical` | `enhanced` | `enhanced-general` | `enhanced-meeting` | `enhanced-phonecall` | `enhanced-finance` | `base` | `meeting` | `phonecall` | `finance` | `conversationalai` | `voicemail` | `video` | string (default: `base-general`) — AI model used to process submitted audio
+- `model` `nova-3` | `nova-3-general` | `nova-3-medical` | `nova-2` | `nova-2-general` | `nova-2-meeting` | `nova-2-finance` | `nova-2-conversationalai` | `nova-2-voicemail` | `nova-2-video` | `nova-2-medical` | `nova-2-drivethru` | `nova-2-automotive` | `nova` | `nova-general` | `nova-phonecall` | `nova-medical` | `enhanced` | `enhanced-general` | `enhanced-meeting` | `enhanced-phonecall` | `enhanced-finance` | `base` | `meeting` | `phonecall` | `finance` | `conversationalai` | `voicemail` | `video` | string — AI model used to process submitted audio
 - `multichannel` boolean (default: `false`) — Transcribe each audio channel independently
 - `numerals` boolean (default: `false`) — Numerals converts numbers from written format to numerical format
 - `paragraphs` boolean (default: `false`) — Splits audio into paragraphs to improve transcript readability
 - `profanity_filter` boolean (default: `false`) — Profanity Filter looks for recognized profanity and converts it to the nearest recognized non-profane word or removes it from the transcript completely
 - `punctuate` boolean (default: `false`) — Add punctuation and capitalization to the transcript
-- `redact` string | `pci` | `pii` | `numbers`[] (default: `false`) — Redaction removes sensitive information from your transcripts
+- `redact` string | `pci` | `pii` | `numbers`[] — Redaction removes sensitive information from your transcripts
 - `replace` string | string[] — Search for terms or phrases in submitted audio and replaces them
 - `search` string | string[] — Search for terms or phrases in submitted audio
 - `smart_format` boolean (default: `false`) — Apply formatting to transcript output. When set to true, additional formatting will be applied to transcripts to improve readability
 - `utterances` boolean (default: `false`) — Segments speech into meaningful semantic units
 - `utt_split` number (default: `0.8`) — Seconds to wait before detecting a pause between words in submitted audio
-- `version` `latest` | string (default: `latest`) — Version of an AI model to use
+- `version` `latest` | string — Version of an AI model to use
 - `mip_opt_out` boolean (default: `false`) — Opts out requests from the Deepgram Model Improvement Program. Refer to our Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
 
 #### Request Body
@@ -77,8 +76,6 @@ Transcribe audio and video using Deepgram's speech-to-text REST API
 **application/json**
 
 - `url` string **(required)**
-
-**application/octet-stream**
 
 #### Responses
 
@@ -94,87 +91,54 @@ Transcribe audio and video using Deepgram's speech-to-text WebSocket
 
 #### Connection Parameters
 
-- `callback` any — URL to which we'll make the callback request
+- `callback` any — Any type
 - `callback_method` `POST` | `GET` | `PUT` | `DELETE` (default: `POST`) — HTTP method by which the callback request will be made
-- `channels` any (default: `1`) — The number of channels in the submitted audio
+- `channels` any — Any type
 - `detect_entities` `true` | `false` (default: `false`) — Identifies and extracts key entities from content in submitted audio. Entities appear in final results. When enabled, Punctuation will also be enabled by default
 - `diarize` `true` | `false` (default: `false`) — Defaults to `false`. Recognize speaker changes. Each word in the transcript will be assigned a speaker number starting at 0
 - `dictation` `true` | `false` (default: `false`) — Identify and extract key entities from content in submitted audio
 - `encoding` `linear16` | `linear32` | `flac` | `alaw` | `mulaw` | `amr-nb` | `amr-wb` | `opus` | `ogg-opus` | `speex` | `g729` — Specify the expected encoding of your submitted audio
-- `endpointing` any (default: `10`) — Indicates how long Deepgram will wait to detect whether a speaker has finished speaking or pauses for a significant period of time. When set to a value, the streaming endpoint immediately finalizes the transcription for the processed time range and returns the transcript with a speech_final parameter set to true. Can also be set to false to disable endpointing
-- `extra` any — Arbitrary key-value pairs that are attached to the API response for usage in downstream processing
+- `endpointing` any — Any type
+- `extra` any — Any type
 - `interim_results` `true` | `false` (default: `false`) — Specifies whether the streaming endpoint should provide ongoing transcription updates as more audio is received. When set to true, the endpoint sends continuous updates, meaning transcription results may evolve over time
-- `keyterm` any — Key term prompting can boost specialized terminology and brands. Only compatible with Nova-3
-- `keywords` any — Keywords can boost or suppress specialized terminology and brands
-- `language` any (default: `en`) — The [BCP-47 language tag](https://tools.ietf.org/html/bcp47) that hints at the primary spoken language. Depending on the Model you choose only certain languages are available
-- `mip_opt_out` any (default: `false`) — Opts out requests from the Deepgram Model Improvement Program. Refer to our Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+- `keyterm` any — Any type
+- `keywords` any — Any type
+- `language` any — Any type
+- `mip_opt_out` any — Any type
 - `model` `nova-3` | `nova-3-general` | `nova-3-medical` | `nova-2` | `nova-2-general` | `nova-2-meeting` | `nova-2-finance` | `nova-2-conversationalai` | `nova-2-voicemail` | `nova-2-video` | `nova-2-medical` | `nova-2-drivethru` | `nova-2-automotive` | `nova` | `nova-general` | `nova-phonecall` | `nova-medical` | `enhanced` | `enhanced-general` | `enhanced-meeting` | `enhanced-phonecall` | `enhanced-finance` | `base` | `meeting` | `phonecall` | `finance` | `conversationalai` | `voicemail` | `video` | `custom` — AI model to use for the transcription
 - `multichannel` `true` | `false` (default: `false`) — Transcribe each audio channel independently
 - `numerals` `true` | `false` (default: `false`) — Convert numbers from written format to numerical format
 - `profanity_filter` `true` | `false` (default: `false`) — Profanity Filter looks for recognized profanity and converts it to the nearest recognized non-profane word or removes it from the transcript completely
 - `punctuate` `true` | `false` (default: `false`) — Add punctuation and capitalization to the transcript
 - `redact` `true` | `false` | `pci` | `numbers` | `aggressive_numbers` | `ssn` (default: `false`) — Redaction removes sensitive information from your transcripts
-- `replace` any — Search for terms or phrases in submitted audio and replaces them
-- `sample_rate` any — Sample rate of submitted audio. Required (and only read) when a value is provided for encoding
-- `search` any — Search for terms or phrases in submitted audio
+- `replace` any — Any type
+- `sample_rate` any — Any type
+- `search` any — Any type
 - `smart_format` `true` | `false` (default: `false`) — Apply formatting to transcript output. When set to true, additional formatting will be applied to transcripts to improve readability
-- `tag` any — Label your requests for the purpose of identification during usage reporting
-- `utterance_end_ms` any — Indicates how long Deepgram will wait to send an UtteranceEnd message after a word has been transcribed. Use with interim_results
+- `tag` any — Any type
+- `utterance_end_ms` any — Any type
 - `vad_events` `true` | `false` (default: `false`) — Indicates that speech has started. You'll begin receiving Speech Started messages upon speech starting
-- `version` any (default: `latest`) — Version of an AI model to use
+- `version` any — Any type
 
 #### Client → Server Messages
 
-**ListenV1MediaMessage** — Send audio or video data to be transcribed
+**ListenV1Media** — Client messages
 
-**ListenV1ControlMessage** — Send a Finalize message to flush the WebSocket stream
+**ListenV1Finalize** — Client messages
 
-  - `type` `Finalize` | `CloseStream` | `KeepAlive` **(required)** — Message type identifier
+**ListenV1CloseStream** — Client messages
 
-**ListenV1ControlMessage** — Send a CloseStream message to close the WebSocket stream
-
-  - `type` `Finalize` | `CloseStream` | `KeepAlive` **(required)** — Message type identifier
-
-**ListenV1ControlMessage** — Send a KeepAlive message to keep the WebSocket stream alive
-
-  - `type` `Finalize` | `CloseStream` | `KeepAlive` **(required)** — Message type identifier
+**ListenV1KeepAlive** — Client messages
 
 #### Server → Client Messages
 
-**ListenV1ResultsEvent** — Receive transcription results
+**ListenV1Results** — Server messages
 
-  - `type` `Results` **(required)** — Message type identifier
-  - `channel_index` number[] **(required)** — The index of the channel
-  - `duration` number **(required)** — The duration of the transcription
-  - `start` number **(required)** — The start time of the transcription
-  - `is_final` boolean — Whether the transcription is final
-  - `speech_final` boolean — Whether the transcription is speech final
-  - `channel` { alternatives: { transcript: string, confidence: number, languages: string[], words: object[] }[] } **(required)**
-  - `metadata` { request_id: string, model_info: { name: string, version: string, arch: string }, model_uuid: string } **(required)**
-  - `from_finalize` boolean — Whether the transcription is from a finalize message
-  - `entities` { label: string, value: string, raw_value: string, confidence: number, start_word: integer, end_word: integer }[] — Extracted entities from the audio when detect_entities is enabled. Only present in is_final messages. Returns an empty array if no entities are detected
+**ListenV1Metadata** — Server messages
 
-**ListenV1MetadataEvent** — Receive metadata about the transcription
+**ListenV1UtteranceEnd** — Server messages
 
-  - `type` `Metadata` **(required)** — Message type identifier
-  - `transaction_key` string **(required)** — The transaction key
-  - `request_id` string **(required)** — The request ID
-  - `sha256` string **(required)** — The sha256
-  - `created` string **(required)** — The created
-  - `duration` number **(required)** — The duration
-  - `channels` number **(required)** — The channels
-
-**ListenV1UtteranceEndEvent** — Receive an utterance end event
-
-  - `type` `UtteranceEnd` **(required)** — Message type identifier
-  - `channel` number[] **(required)** — The channel
-  - `last_word_end` number **(required)** — The last word end
-
-**ListenV1SpeechStartedEvent** — Receive a speech started event
-
-  - `type` `SpeechStarted` **(required)** — Message type identifier
-  - `channel` number[] **(required)** — The channel
-  - `timestamp` number **(required)** — The timestamp
+**ListenV1SpeechStarted** — Server messages
 
 ### WebSocket `/v2/listen`
 > Server: `wss://api.deepgram.com`
@@ -185,76 +149,34 @@ for natural voice conversations
 
 #### Connection Parameters
 
-- `model` `flux-general-en` **(required)** — Defines the AI model used to process submitted audio.
+- `model` `flux-general-en` | `flux-general-multi` — Defines the AI model used to process submitted audio.
 - `encoding` `linear16` | `linear32` | `mulaw` | `alaw` | `opus` | `ogg-opus` — Encoding of the audio stream. Required if sending non-containerized/raw audio. If sending containerized audio, this parameter should be omitted.
-- `sample_rate` any — Sample rate of the audio stream in Hz. Required if sending non-containerized/raw audio. If sending containerized audio, this parameter should be omitted.
-- `eager_eot_threshold` any — End-of-turn confidence required to fire an eager end-of-turn event.
-When set, enables `EagerEndOfTurn` and `TurnResumed` events. Valid
-Values 0.3 - 0.9.
-
-- `eot_threshold` any (default: `0.7`) — End-of-turn confidence required to finish a turn. Valid Values 0.5 -
-0.9.
-
-- `eot_timeout_ms` any (default: `5000`) — A turn will be finished when this much time has passed after speech,
-regardless of EOT confidence.
-
+- `sample_rate` any — Any type
+- `eager_eot_threshold` any — Any type
+- `eot_threshold` any — Any type
+- `eot_timeout_ms` any — Any type
 - `keyterm` string | string[] — Keyterm prompting can improve recognition of specialized terminology.
 Pass multiple keyterm query parameters to boost multiple keyterms.
 
-- `mip_opt_out` any — Opts out requests from the Deepgram Model Improvement Program. Refer
-to our Docs for pricing impacts before setting this to true.
-https://dpgr.am/deepgram-mip
-
-- `tag` any — Label your requests for the purpose of identification during usage
-reporting
-
+- `mip_opt_out` any — Any type
+- `tag` any — Any type
 
 #### Client → Server Messages
 
-**ListenV2MediaMessage** — Send audio or video data to be transcribed
+**ListenV2Media** — Client messages
 
-**ListenV2ControlMessage** — Send a CloseStream message to close the WebSocket stream
+**ListenV2CloseStream** — Client messages
 
-  - `type` `Finalize` | `CloseStream` | `KeepAlive` **(required)** — Message type identifier
+**ListenV2Configure** — Client messages
 
 #### Server → Client Messages
 
-**ListenV2ConnectedEvent** — Receive a connected message
+**ListenV2Connected** — Server messages
 
-  - `type` `Connected` **(required)** — Message type identifier
-  - `request_id` string **(required)** — The unique identifier of the request
-  - `sequence_id` number **(required)** — Starts at `0` and increments for each message the server sends
-to the client.  This includes messages of other types, like
-`TurnInfo` messages.
+**ListenV2TurnInfo** — Server messages
 
+**ListenV2ConfigureSuccess** — Server messages
 
-**ListenV2TurnInfo** — Receive a turn info message
+**ListenV2ConfigureFailure** — Server messages
 
-  - `type` `TurnInfo` **(required)**
-  - `request_id` string **(required)** — The unique identifier of the request
-  - `sequence_id` number **(required)** — Starts at `0` and increments for each message the server sends to the client.  This includes messages of other types, like `Connected` messages.
-
-  - `event` `Update` | `StartOfTurn` | `EagerEndOfTurn` | `TurnResumed` | `EndOfTurn` **(required)** — The type of event being reported.
-
-- **Update** - Additional audio has been transcribed, but the turn state hasn't changed
-- **StartOfTurn** - The user has begun speaking for the first time in the turn
-- **EagerEndOfTurn** - The system has moderate confidence that the user has finished speaking for the turn. This is an opportunity to begin preparing an agent reply
-- **TurnResumed** - The system detected that speech had ended and therefore sent an **EagerEndOfTurn** event, but speech is actually continuing for this turn
-- **EndOfTurn** - The user has finished speaking for the turn
-
-  - `turn_index` number **(required)** — The index of the current turn
-  - `audio_window_start` number **(required)** — Start time in seconds of the audio range that was transcribed
-  - `audio_window_end` number **(required)** — End time in seconds of the audio range that was transcribed
-  - `transcript` string **(required)** — Text that was said over the course of the current turn
-  - `words` { word: string, confidence: number }[] **(required)** — The words in the `transcript`
-  - `end_of_turn_confidence` number **(required)** — Confidence that no more speech is coming in this turn
-
-**ListenV2FatalErrorEvent** — Receive a fatal error message
-
-  - `type` `Error` **(required)** — Message type identifier
-  - `sequence_id` number **(required)** — Starts at `0` and increments for each message the server sends
-to the client.  This includes messages of other types, like
-`Connected` messages.
-
-  - `code` string **(required)** — A string code describing the error, e.g. `INTERNAL_SERVER_ERROR`
-  - `description` string **(required)** — Prose description of the error
+**ListenV2FatalError** — Server messages

--- a/skills/api/references/models.md
+++ b/skills/api/references/models.md
@@ -25,8 +25,33 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 
 ## REST API
 
+### GET `/v1/projects/{project_id}/models`
+
+List Project Models
+
+Returns metadata on all the latest models that a specific project has access to, including non-public models
+
+#### Query Parameters
+
+- `include_outdated` boolean — returns non-latest versions of models
+
+#### Responses
+
+**200**: A list of models
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/models/{model_id}`
+
+Get a Project Model
+
+Returns metadata for a specific model
+
+#### Responses
+
+**200**: A model object that can be either STT or TTS
+**400**: Invalid Request
+
 ### GET `/v1/models`
-> Server: `https://api.deepgram.com`
 
 List Models
 
@@ -42,7 +67,6 @@ Returns metadata on all the latest public models. To retrieve custom models, use
 **400**: Invalid Request
 
 ### GET `/v1/models/{model_id}`
-> Server: `https://api.deepgram.com`
 
 Get a specific Model
 

--- a/skills/api/references/projects.md
+++ b/skills/api/references/projects.md
@@ -26,7 +26,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### GET `/v1/projects`
-> Server: `https://api.deepgram.com`
 
 List Projects
 
@@ -38,7 +37,6 @@ Retrieves basic information about the projects associated with the API key
 **400**: Invalid Request
 
 ### GET `/v1/projects/{project_id}`
-> Server: `https://api.deepgram.com`
 
 Get a Project
 
@@ -55,7 +53,6 @@ Retrieves information about the specified project
 **400**: Invalid Request
 
 ### PATCH `/v1/projects/{project_id}`
-> Server: `https://api.deepgram.com`
 
 Update a Project
 
@@ -73,7 +70,6 @@ Updates the name or other properties of an existing project
 **400**: Invalid Request
 
 ### DELETE `/v1/projects/{project_id}`
-> Server: `https://api.deepgram.com`
 
 Delete a Project
 
@@ -84,71 +80,120 @@ Deletes the specified project
 **200**: A project
 **400**: Invalid Request
 
-### GET `/v1/projects/{project_id}/balances`
-> Server: `https://api.deepgram.com`
+### DELETE `/v1/projects/{project_id}/leave`
 
-Get Project Balances
+Leave a Project
 
-Generates a list of outstanding balances for the specified project
-
-#### Responses
-
-**200**: A list of outstanding balances
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/balances/{balance_id}`
-> Server: `https://api.deepgram.com`
-
-Get a Project Balance
-
-Retrieves details about the specified balance
+Removes the authenticated account from the specific project
 
 #### Responses
 
-**200**: A specific balance
+**200**: Successfully removed account from project
 **400**: Invalid Request
 
-### GET `/v1/projects/{project_id}/billing/breakdown`
-> Server: `https://api.deepgram.com`
+### GET `/v1/projects/{project_id}/keys`
 
-Get Project Billing Breakdown
+List Project Keys
 
-Retrieves the billing summary for a specific project, with various filter options or by grouping options.
+Retrieves all API keys associated with the specified project
 
 #### Query Parameters
 
-- `start` string — Start date of the requested date range. Format accepted is YYYY-MM-DD
-- `end` string — End date of the requested date range. Format accepted is YYYY-MM-DD
-- `accessor` string — Filter for requests where a specific accessor was used
-- `deployment` `hosted` | `beta` | `self-hosted` — Filter for requests where a specific deployment was used
-- `tag` string — Filter for requests where a specific tag was used
-- `line_item` string — Filter requests by line item (e.g. streaming::nova-3)
-- `grouping` `accessor` | `deployment` | `line_item` | `tags`[] — Group billing breakdown by one or more dimensions (accessor, deployment, line_item, tags)
+- `status` `active` | `expired` — Only return keys with a specific status
 
 #### Responses
 
-**200**: Billing breakdown response
+**200**: A list of API keys
 **400**: Invalid Request
 
-### GET `/v1/projects/{project_id}/billing/fields`
-> Server: `https://api.deepgram.com`
+### POST `/v1/projects/{project_id}/keys`
 
-List Project Billing Fields
+Create a Project Key
 
-Lists the accessors, deployment types, tags, and line items used for billing data in the specified time period. Use this endpoint if you want to filter your results from the Billing Breakdown endpoint and want to know what filters are available.
+Creates a new API key with specified settings for the project
 
-#### Query Parameters
+#### Request Body
 
-- `start` string — Start date of the requested date range. Format accepted is YYYY-MM-DD
-- `end` string — End date of the requested date range. Format accepted is YYYY-MM-DD
+**application/json**
 
 #### Responses
 
-**200**: A list of billing fields for a specific project
+**200**: API key created successfully
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/keys/{key_id}`
+
+Get a Project Key
+
+Retrieves information about a specified API key
+
+#### Responses
+
+**200**: A specific API key
+**400**: Invalid Request
+
+### DELETE `/v1/projects/{project_id}/keys/{key_id}`
+
+Delete a Project Key
+
+Deletes an API key for a specific project
+
+#### Responses
+
+**200**: API key deleted
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/members`
+
+List Project Members
+
+Retrieves a list of members for a given project
+
+#### Responses
+
+**200**: A list of members for a given project
+**400**: Invalid Request
+
+### DELETE `/v1/projects/{project_id}/members/{member_id}`
+
+Delete a Project Member
+
+Removes a member from the project using their unique member ID
+
+#### Responses
+
+**200**: Delete the specific member from the project
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/members/{member_id}/scopes`
+
+List Project Member Scopes
+
+Retrieves a list of scopes for a specific member
+
+#### Responses
+
+**200**: A list of scopes for a specific member
+**400**: Invalid Request
+
+### PUT `/v1/projects/{project_id}/members/{member_id}/scopes`
+
+Update Project Member Scopes
+
+Updates the scopes for a specific member
+
+#### Request Body
+
+**application/json**
+
+- `scope` string **(required)** — A scope to update
+
+#### Responses
+
+**200**: Updated the scopes for a specific member
 **400**: Invalid Request
 
 ### GET `/v1/projects/{project_id}/invites`
-> Server: `https://api.deepgram.com`
 
 List Project Invites
 
@@ -160,7 +205,6 @@ Generates a list of invites for a specific project
 **400**: Invalid Request
 
 ### POST `/v1/projects/{project_id}/invites`
-> Server: `https://api.deepgram.com`
 
 Create a Project Invite
 
@@ -179,7 +223,6 @@ Generates an invite for a specific project
 **400**: Invalid Request
 
 ### DELETE `/v1/projects/{project_id}/invites/{email}`
-> Server: `https://api.deepgram.com`
 
 Delete a Project Invite
 
@@ -190,180 +233,7 @@ Deletes an invite for a specific project
 **200**: The invite was successfully deleted
 **400**: Invalid Request
 
-### GET `/v1/projects/{project_id}/keys`
-> Server: `https://api.deepgram.com`
-
-List Project Keys
-
-Retrieves all API keys associated with the specified project
-
-#### Query Parameters
-
-- `status` `active` | `expired` — Only return keys with a specific status
-
-#### Responses
-
-**200**: A list of API keys
-**400**: Invalid Request
-
-### POST `/v1/projects/{project_id}/keys`
-> Server: `https://api.deepgram.com`
-
-Create a Project Key
-
-Creates a new API key with specified settings for the project
-
-#### Request Body
-
-**application/json**
-
-- `comment` string **(required)**
-- `scopes` string[] **(required)**
-- `tags` string[]
-- `expiration_date` string
-- `time_to_live_in_seconds` number
-
-#### Responses
-
-**200**: API key created successfully
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/keys/{key_id}`
-> Server: `https://api.deepgram.com`
-
-Get a Project Key
-
-Retrieves information about a specified API key
-
-#### Responses
-
-**200**: A specific API key
-**400**: Invalid Request
-
-### DELETE `/v1/projects/{project_id}/keys/{key_id}`
-> Server: `https://api.deepgram.com`
-
-Delete a Project Key
-
-Deletes an API key for a specific project
-
-#### Responses
-
-**200**: API key deleted
-**400**: Invalid Request
-
-### DELETE `/v1/projects/{project_id}/leave`
-> Server: `https://api.deepgram.com`
-
-Leave a Project
-
-Removes the authenticated account from the specific project
-
-#### Responses
-
-**200**: Successfully removed account from project
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/members`
-> Server: `https://api.deepgram.com`
-
-List Project Members
-
-Retrieves a list of members for a given project
-
-#### Responses
-
-**200**: A list of members for a given project
-**400**: Invalid Request
-
-### DELETE `/v1/projects/{project_id}/members/{member_id}`
-> Server: `https://api.deepgram.com`
-
-Delete a Project Member
-
-Removes a member from the project using their unique member ID
-
-#### Responses
-
-**200**: Delete the specific member from the project
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/members/{member_id}/scopes`
-> Server: `https://api.deepgram.com`
-
-List Project Member Scopes
-
-Retrieves a list of scopes for a specific member
-
-#### Responses
-
-**200**: A list of scopes for a specific member
-**400**: Invalid Request
-
-### PUT `/v1/projects/{project_id}/members/{member_id}/scopes`
-> Server: `https://api.deepgram.com`
-
-Update Project Member Scopes
-
-Updates the scopes for a specific member
-
-#### Request Body
-
-**application/json**
-
-- `scope` string **(required)** — A scope to update
-
-#### Responses
-
-**200**: Updated the scopes for a specific member
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/models`
-> Server: `https://api.deepgram.com`
-
-List Project Models
-
-Returns metadata on all the latest models that a specific project has access to, including non-public models
-
-#### Query Parameters
-
-- `include_outdated` boolean — returns non-latest versions of models
-
-#### Responses
-
-**200**: A list of models
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/models/{model_id}`
-> Server: `https://api.deepgram.com`
-
-Get a Project Model
-
-Returns metadata for a specific model
-
-#### Responses
-
-**200**: A model object that can be either STT or TTS
-**400**: Invalid Request
-
-### GET `/v1/projects/{project_id}/purchases`
-> Server: `https://api.deepgram.com`
-
-List Project Purchases
-
-Returns the original purchased amount on an order transaction
-
-#### Query Parameters
-
-- `limit` number (default: `10`) — Number of results to return per page. Default 10. Range [1,1000]
-
-#### Responses
-
-**200**: A list of purchases for a specific project
-**400**: Invalid Request
-
 ### GET `/v1/projects/{project_id}/requests`
-> Server: `https://api.deepgram.com`
 
 List Project Requests
 
@@ -388,7 +258,6 @@ Generates a list of requests for a specific project
 **400**: Invalid Request
 
 ### GET `/v1/projects/{project_id}/requests/{request_id}`
-> Server: `https://api.deepgram.com`
 
 Get a Project Request
 
@@ -400,7 +269,6 @@ Retrieves a specific request for a specific project
 **400**: Invalid Request
 
 ### GET `/v1/projects/{project_id}/usage`
-> Server: `https://api.deepgram.com`
 
 Get Project Usage
 
@@ -458,8 +326,23 @@ Retrieves the usage for a specific project. Use Get Project Usage Breakdown for 
 **200**: A specific request for a specific project
 **400**: Invalid Request
 
+### GET `/v1/projects/{project_id}/usage/fields`
+
+List Project Usage Fields
+
+Lists the features, models, tags, languages, and processing method used for requests in the specified project
+
+#### Query Parameters
+
+- `start` string — Start date of the requested date range. Format accepted is YYYY-MM-DD
+- `end` string — End date of the requested date range. Format accepted is YYYY-MM-DD
+
+#### Responses
+
+**200**: A list of fields for a specific project
+**400**: Invalid Request
+
 ### GET `/v1/projects/{project_id}/usage/breakdown`
-> Server: `https://api.deepgram.com`
 
 Get Project Usage Breakdown
 
@@ -518,12 +401,54 @@ Retrieves the usage breakdown for a specific project, with various filter option
 **200**: Usage breakdown response
 **400**: Invalid Request
 
-### GET `/v1/projects/{project_id}/usage/fields`
-> Server: `https://api.deepgram.com`
+### GET `/v1/projects/{project_id}/balances`
 
-List Project Usage Fields
+Get Project Balances
 
-Lists the features, models, tags, languages, and processing method used for requests in the specified project
+Generates a list of outstanding balances for the specified project
+
+#### Responses
+
+**200**: A list of outstanding balances
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/balances/{balance_id}`
+
+Get a Project Balance
+
+Retrieves details about the specified balance
+
+#### Responses
+
+**200**: A specific balance
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/billing/breakdown`
+
+Get Project Billing Breakdown
+
+Retrieves the billing summary for a specific project, with various filter options or by grouping options.
+
+#### Query Parameters
+
+- `start` string — Start date of the requested date range. Format accepted is YYYY-MM-DD
+- `end` string — End date of the requested date range. Format accepted is YYYY-MM-DD
+- `accessor` string — Filter for requests where a specific accessor was used
+- `deployment` `hosted` | `beta` | `self-hosted` — Filter for requests where a specific deployment was used
+- `tag` string — Filter for requests where a specific tag was used
+- `line_item` string — Filter requests by line item (e.g. streaming::nova-3)
+- `grouping` `accessor` | `deployment` | `line_item` | `tags`[] — Group billing breakdown by one or more dimensions (accessor, deployment, line_item, tags)
+
+#### Responses
+
+**200**: Billing breakdown response
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/billing/fields`
+
+List Project Billing Fields
+
+Lists the accessors, deployment types, tags, and line items used for billing data in the specified time period. Use this endpoint if you want to filter your results from the Billing Breakdown endpoint and want to know what filters are available.
 
 #### Query Parameters
 
@@ -532,5 +457,20 @@ Lists the features, models, tags, languages, and processing method used for requ
 
 #### Responses
 
-**200**: A list of fields for a specific project
+**200**: A list of billing fields for a specific project
+**400**: Invalid Request
+
+### GET `/v1/projects/{project_id}/purchases`
+
+List Project Purchases
+
+Returns the original purchased amount on an order transaction
+
+#### Query Parameters
+
+- `limit` number (default: `10`) — Number of results to return per page. Default 10. Range [1,1000]
+
+#### Responses
+
+**200**: A list of purchases for a specific project
 **400**: Invalid Request

--- a/skills/api/references/read.md
+++ b/skills/api/references/read.md
@@ -27,7 +27,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### POST `/v1/read`
-> Server: `https://api.deepgram.com`
 
 Analyze text content
 

--- a/skills/api/references/self-hosted.md
+++ b/skills/api/references/self-hosted.md
@@ -25,7 +25,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### GET `/v1/projects/{project_id}/self-hosted/distribution/credentials`
-> Server: `https://api.deepgram.com`
 
 List Project Self-Hosted Distribution Credentials
 
@@ -37,7 +36,6 @@ Lists sets of distribution credentials for the specified project
 **400**: Invalid Request
 
 ### POST `/v1/projects/{project_id}/self-hosted/distribution/credentials`
-> Server: `https://api.deepgram.com`
 
 Create a Project Self-Hosted Distribution Credential
 
@@ -45,7 +43,7 @@ Creates a set of distribution credentials for the specified project
 
 #### Query Parameters
 
-- `scopes` `self-hosted:products` | `self-hosted:product:api` | `self-hosted:product:engine` | `self-hosted:product:license-proxy` | `self-hosted:product:dgtools` | `self-hosted:product:billing` | `self-hosted:product:hotpepper` | `self-hosted:product:metrics-server`[] (default: `self-hosted:products`) — List of permission scopes for the credentials
+- `scopes` `self-hosted:products` | `self-hosted:product:api` | `self-hosted:product:engine` | `self-hosted:product:license-proxy` | `self-hosted:product:dgtools` | `self-hosted:product:billing` | `self-hosted:product:hotpepper` | `self-hosted:product:metrics-server`[] — List of permission scopes for the credentials
 - `provider` `quay` (default: `quay`) — The provider of the distribution service
 
 #### Request Body
@@ -60,7 +58,6 @@ Creates a set of distribution credentials for the specified project
 **400**: Invalid Request
 
 ### GET `/v1/projects/{project_id}/self-hosted/distribution/credentials/{distribution_credentials_id}`
-> Server: `https://api.deepgram.com`
 
 Get a Project Self-Hosted Distribution Credential
 
@@ -72,7 +69,6 @@ Returns a set of distribution credentials for the specified project
 **400**: Invalid Request
 
 ### DELETE `/v1/projects/{project_id}/self-hosted/distribution/credentials/{distribution_credentials_id}`
-> Server: `https://api.deepgram.com`
 
 Delete a Project Self-Hosted Distribution Credential
 

--- a/skills/api/references/speak.md
+++ b/skills/api/references/speak.md
@@ -27,7 +27,6 @@ Example: `Authorization: Bearer eyJhbGciOiJ...`
 ## REST API
 
 ### POST `/v1/speak`
-> Server: `https://api.deepgram.com`
 
 Text to Speech transformation
 
@@ -39,11 +38,12 @@ Convert text into natural-sounding speech using Deepgram's TTS REST API
 - `callback_method` `POST` | `PUT` (default: `POST`) — HTTP method by which the callback request will be made
 - `mip_opt_out` boolean (default: `false`) — Opts out requests from the Deepgram Model Improvement Program. Refer to our Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
 - `tag` string | string[] — Label your requests for the purpose of identification during usage reporting
-- `bit_rate` `32000` | `48000` | number | number (default: `48000`) — The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
-- `container` `none` | `wav` | `wav` | `wav` | `ogg` (default: `wav`) — Container specifies the file format wrapper for the output audio. The available options depend on the encoding type.
-- `encoding` `linear16` | `flac` | `mulaw` | `alaw` | `mp3` | `opus` | `aac` (default: `mp3`) — Encoding allows you to specify the expected encoding of your audio output
+- `bit_rate` `32000` | `48000` | number | number — The bitrate of the audio in bits per second. Choose from predefined ranges or specific values based on the encoding type.
+- `container` `none` | `wav` | `wav` | `wav` | `ogg` — Container specifies the file format wrapper for the output audio. The available options depend on the encoding type.
+- `encoding` `linear16` | `flac` | `mulaw` | `alaw` | `mp3` | `opus` | `aac` — Encoding allows you to specify the expected encoding of your audio output
 - `model` `aura-asteria-en` | `aura-luna-en` | `aura-stella-en` | `aura-athena-en` | `aura-hera-en` | `aura-orion-en` | `aura-arcas-en` | `aura-perseus-en` | `aura-angus-en` | `aura-orpheus-en` | `aura-helios-en` | `aura-zeus-en` | `aura-2-amalthea-en` | `aura-2-andromeda-en` | `aura-2-apollo-en` | `aura-2-arcas-en` | `aura-2-aries-en` | `aura-2-asteria-en` | `aura-2-athena-en` | `aura-2-atlas-en` | `aura-2-aurora-en` | `aura-2-callista-en` | `aura-2-cordelia-en` | `aura-2-cora-en` | `aura-2-delia-en` | `aura-2-draco-en` | `aura-2-electra-en` | `aura-2-harmonia-en` | `aura-2-helena-en` | `aura-2-hera-en` | `aura-2-hermes-en` | `aura-2-hyperion-en` | `aura-2-iris-en` | `aura-2-janus-en` | `aura-2-juno-en` | `aura-2-jupiter-en` | `aura-2-luna-en` | `aura-2-mars-en` | `aura-2-minerva-en` | `aura-2-neptune-en` | `aura-2-odysseus-en` | `aura-2-ophelia-en` | `aura-2-orion-en` | `aura-2-orpheus-en` | `aura-2-pandora-en` | `aura-2-phoebe-en` | `aura-2-pluto-en` | `aura-2-saturn-en` | `aura-2-selene-en` | `aura-2-thalia-en` | `aura-2-theia-en` | `aura-2-vesta-en` | `aura-2-zeus-en` | `aura-2-sirio-es` | `aura-2-nestor-es` | `aura-2-carina-es` | `aura-2-celeste-es` | `aura-2-alvaro-es` | `aura-2-diana-es` | `aura-2-aquila-es` | `aura-2-selena-es` | `aura-2-estrella-es` | `aura-2-javier-es` (default: `aura-asteria-en`) — AI model used to process submitted text
-- `sample_rate` `8000` | `16000` | `24000` | `32000` | `48000` | `8000` | `16000` | `8000` | `16000` | `22050` | `48000` (default: `24000`) — Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+- `sample_rate` `8000` | `16000` | `24000` | `32000` | `48000` | `8000` | `16000` | `8000` | `16000` | `22050` | `48000` — Sample Rate specifies the sample rate for the output audio. Based on the encoding, different sample rates are supported. For some encodings, the sample rate is not configurable
+- `speed` number (default: `1`) — Speaking rate multiplier that adjusts the pace of generated speech while preserving natural prosody and voice quality. Not yet supported in all languages.
 
 #### Request Body
 
@@ -66,53 +66,29 @@ Convert text into natural-sounding speech using Deepgram's TTS WebSocket
 #### Connection Parameters
 
 - `encoding` `linear16` | `mulaw` | `alaw` (default: `linear16`) — Encoding allows you to specify the expected encoding of your audio output for streaming TTS. Only streaming-compatible encodings are supported.
-- `mip_opt_out` any (default: `false`) — Opts out requests from the Deepgram Model Improvement Program. Refer to our Docs for pricing impacts before setting this to true. https://dpgr.am/deepgram-mip
+- `mip_opt_out` any — Any type
 - `model` `aura-asteria-en` | `aura-luna-en` | `aura-stella-en` | `aura-athena-en` | `aura-hera-en` | `aura-orion-en` | `aura-arcas-en` | `aura-perseus-en` | `aura-angus-en` | `aura-orpheus-en` | `aura-helios-en` | `aura-zeus-en` | `aura-2-amalthea-en` | `aura-2-andromeda-en` | `aura-2-apollo-en` | `aura-2-arcas-en` | `aura-2-aries-en` | `aura-2-asteria-en` | `aura-2-athena-en` | `aura-2-atlas-en` | `aura-2-aurora-en` | `aura-2-callista-en` | `aura-2-cordelia-en` | `aura-2-cora-en` | `aura-2-delia-en` | `aura-2-draco-en` | `aura-2-electra-en` | `aura-2-harmonia-en` | `aura-2-helena-en` | `aura-2-hera-en` | `aura-2-hermes-en` | `aura-2-hyperion-en` | `aura-2-iris-en` | `aura-2-janus-en` | `aura-2-juno-en` | `aura-2-jupiter-en` | `aura-2-luna-en` | `aura-2-mars-en` | `aura-2-minerva-en` | `aura-2-neptune-en` | `aura-2-odysseus-en` | `aura-2-ophelia-en` | `aura-2-orion-en` | `aura-2-orpheus-en` | `aura-2-pandora-en` | `aura-2-phoebe-en` | `aura-2-pluto-en` | `aura-2-saturn-en` | `aura-2-selene-en` | `aura-2-thalia-en` | `aura-2-theia-en` | `aura-2-vesta-en` | `aura-2-zeus-en` | `aura-2-sirio-es` | `aura-2-nestor-es` | `aura-2-carina-es` | `aura-2-celeste-es` | `aura-2-alvaro-es` | `aura-2-diana-es` | `aura-2-aquila-es` | `aura-2-selena-es` | `aura-2-estrella-es` | `aura-2-javier-es` (default: `aura-asteria-en`) — AI model used to process submitted text
 - `sample_rate` `8000` | `16000` | `24000` | `32000` | `48000` (default: `24000`) — Sample Rate specifies the sample rate for the output audio. Based on encoding 8000 or 24000 are possible defaults. For some encodings sample rate is not configurable.
+- `speed` number (default: `1`) — Speaking rate multiplier that adjusts the pace of generated speech while preserving natural prosody and voice quality. Not yet supported in all languages.
 
 #### Client → Server Messages
 
-**SpeakV1TextMessage** — Text to convert to audio
+**SpeakV1Text** — Client messages
 
-  - `type` `Speak` **(required)** — Message type identifier
-  - `text` string **(required)** — The input text to be converted to speech
+**SpeakV1Flush** — Client messages
 
-**SpeakV1ControlMessage** — Flush the buffer and receive the final audio for text sent so far
+**SpeakV1Clear** — Client messages
 
-  - `type` `Flush` | `Clear` | `Close` **(required)** — Message type identifier
-
-**SpeakV1ControlMessage** — Clear the buffer and start a new audio generation. Potentially destructive operation for any text in the buffer
-
-  - `type` `Flush` | `Clear` | `Close` **(required)** — Message type identifier
-
-**SpeakV1ControlMessage** — Flush the buffer and close the connection gracefully after all audio is generated
-
-  - `type` `Flush` | `Clear` | `Close` **(required)** — Message type identifier
+**SpeakV1Close** — Client messages
 
 #### Server → Client Messages
 
-**SpeakV1AudioChunkEvent** — Receive audio chunks as they are generated
+**SpeakV1Audio** — Server messages
 
-**SpeakV1MetadataEvent** — Receive metadata about the audio generation
+**SpeakV1Metadata** — Server messages
 
-  - `type` `Metadata` **(required)** — Message type identifier
-  - `request_id` string **(required)** — Unique identifier for the request
-  - `model_name` string **(required)** — Name of the model being used
-  - `model_version` string **(required)** — Version of the model being used
-  - `model_uuid` string **(required)** — Unique identifier for the model
+**SpeakV1Flushed** — Server messages
 
-**SpeakV1ControlEvent** — Receive metadata about the audio generation
+**SpeakV1Cleared** — Server messages
 
-  - `type` `Flushed` | `Cleared` **(required)** — Message type identifier
-  - `sequence_id` number **(required)** — The sequence ID of the response
-
-**SpeakV1ControlEvent** — Receive metadata about the audio generation
-
-  - `type` `Flushed` | `Cleared` **(required)** — Message type identifier
-  - `sequence_id` number **(required)** — The sequence ID of the response
-
-**SpeakV1WarningEvent** — Receive a warning about the audio generation
-
-  - `type` `Warning` **(required)** — Message type identifier
-  - `description` string **(required)** — A description of what went wrong
-  - `code` string **(required)** — Error code identifying the type of error
+**SpeakV1Warning** — Server messages

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -19,9 +19,16 @@ Have a question? Get answers from Deepgram's AI assistant at <https://developers
 
 ### Speech-to-Text (STT)
 
-Transcribe audio and video into text — live streaming or pre-recorded.
+Transcribe audio and video into text. Deepgram ships two actively maintained, next-gen model families — pick the one that matches your use case.
 
-- [Getting Started](https://developers.deepgram.com/docs/stt/getting-started)
+- **Nova** (`/v1/listen`) — general-purpose transcription (captions, subtitles, batch files, live streams). Rich feature set including intelligence overlays (diarize, summarize, sentiment, topics, intents).
+- **Flux** (`/v2/listen`) — conversational-audio transcription for voice agents and interactive assistants. Built-in turn-taking (EOT events, mid-session reconfig).
+
+Docs:
+- [STT Getting Started (Nova)](https://developers.deepgram.com/docs/stt/getting-started)
+- [Flux Quickstart](https://developers.deepgram.com/docs/flux/quickstart)
+- [Nova 3 → Flux migration](https://developers.deepgram.com/docs/flux/nova-3-migration)
+- [Flux language prompting](https://developers.deepgram.com/docs/flux/language-prompting)
 
 ### Text-to-Speech (TTS)
 

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -53,6 +53,30 @@ Full reference for all Deepgram REST and WebSocket APIs.
 
 - [API Reference](https://developers.deepgram.com/reference/deepgram-api-overview)
 
+## SDK-Specific Skills
+
+For language-idiomatic code patterns (imports, async idioms, error handling, type shapes), install the Deepgram SDK's own skills. Every Deepgram SDK publishes 7 product skills plus a maintainer skill:
+
+```bash
+npx skills add deepgram/deepgram-python-sdk     # Python
+npx skills add deepgram/deepgram-js-sdk         # JavaScript / TypeScript
+npx skills add deepgram/deepgram-java-sdk       # Java
+npx skills add deepgram/deepgram-go-sdk         # Go
+npx skills add deepgram/deepgram-rust-sdk       # Rust
+npx skills add deepgram/deepgram-swift-sdk      # Swift
+npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
+npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
+npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
+```
+
+## Related Deepgram skills
+
+- `api` — consolidated REST + WebSocket API reference
+- `recipes` — minimal runnable feature snippets per language
+- `examples` — full integration examples with third-party platforms
+- `starters` — runnable starter apps (framework × feature)
+- `setup-mcp` — Deepgram MCP server installation
+
 ## MCP Server
 
 For direct documentation querying from your AI coding tool, use `/deepgram:mcp` to set up the Deepgram MCP server.

--- a/skills/examples/SKILL.md
+++ b/skills/examples/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: examples
+description: >
+  Find working Deepgram integration examples with third-party platforms and frameworks.
+  Use whenever someone wants to integrate Deepgram with Twilio, LiveKit, LangChain,
+  Vercel AI SDK, Discord, Vonage, Pipecat, Expo, FastAPI, Cloudflare Workers, Slack,
+  Telegram, LlamaIndex, Zoom, Next.js, Nuxt, Django, SvelteKit, NestJS, Spring Boot,
+  CrewAI, Riverside, SignalWire, and more. Examples are full runnable integration
+  demos, not minimal feature snippets.
+---
+
+# Deepgram Examples
+
+Working examples showing how to use Deepgram with popular platforms, frameworks, and ecosystems.
+
+## When to use examples
+
+- You're integrating Deepgram with a specific third-party service (telephony, video, LLM frameworks, bots, cloud platforms)
+- You want a runnable demo of a complete integration, not just SDK-level code
+- You want to see Deepgram slotted into a real-world architecture
+
+**Use a different skill when:**
+- You want a minimal feature snippet (one product, one language, < 50 lines) → `recipes` skill
+- You want a clean starter app to extend with no third-party service → `starters` skill
+- You want the raw API contract → `api` skill
+
+## Browse examples
+
+Repository: <https://github.com/deepgram/examples>
+
+Examples are numbered (010, 020, ...) and each is a self-contained integration.
+
+## Category map
+
+| Category | Integrations |
+|---|---|
+| **Telephony** | Twilio, Vonage, SignalWire, Daily.co, Asterisk/FreeSWITCH |
+| **Voice AI frameworks** | LiveKit Agents, Pipecat, OpenAI Agents SDK, CrewAI |
+| **LLM frameworks** | LangChain, LlamaIndex, Vercel AI SDK |
+| **Chat platforms** | Discord, Slack, Telegram |
+| **Web frameworks** | Next.js, Nuxt, Django, SvelteKit, NestJS, Express + React, FastAPI, Spring Boot |
+| **Mobile / desktop** | Expo, Flutter, Swift iOS, Kotlin Android, Tauri, Electron |
+| **Cloud / serverless** | AWS Lambda, Cloudflare Workers |
+| **Recording platforms** | Zoom, Riverside.fm |
+| **Browser / no-bundler** | Vanilla JavaScript |
+| **Low-code / automation** | n8n community nodes |
+
+## Install the related SDK skills
+
+If your integration uses a specific Deepgram SDK, install its skills for language-idiomatic patterns:
+
+```bash
+npx skills add deepgram/deepgram-python-sdk     # Python
+npx skills add deepgram/deepgram-js-sdk         # Node.js / TypeScript
+npx skills add deepgram/deepgram-java-sdk       # Java
+npx skills add deepgram/deepgram-go-sdk         # Go
+npx skills add deepgram/deepgram-rust-sdk       # Rust
+npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
+npx skills add deepgram/deepgram-swift-sdk      # Swift
+npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
+npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
+```
+
+## Related Deepgram skills
+
+- `api` — consolidated REST + WebSocket API reference
+- `recipes` — focused feature snippets (one feature, one language)
+- `starters` — starter apps without third-party integrations
+- `docs` — documentation finder
+- `setup-mcp` — Deepgram MCP server installation

--- a/skills/examples/SKILL.md
+++ b/skills/examples/SKILL.md
@@ -32,18 +32,19 @@ Examples are numbered (010, 020, ...) and each is a self-contained integration.
 
 ## Category map
 
-| Category | Integrations |
-|---|---|
-| **Telephony** | Twilio, Vonage, SignalWire, Daily.co, Asterisk/FreeSWITCH |
-| **Voice AI frameworks** | LiveKit Agents, Pipecat, OpenAI Agents SDK, CrewAI |
+| Category | Integrations | Common STT choice |
+|---|---|---|
+| **Telephony** | Twilio, Vonage, SignalWire, Daily.co, Asterisk/FreeSWITCH | Nova live (`/v1/listen`) for call transcription; Flux (`/v2/listen`) for AI-agent calls |
+| **Voice AI frameworks** | LiveKit Agents, Pipecat, OpenAI Agents SDK, CrewAI | Flux (`/v2/listen`) — built-in turn detection; or Voice Agent (`/v1/agent/converse`) for full-pipeline |
 | **LLM frameworks** | LangChain, LlamaIndex, Vercel AI SDK |
-| **Chat platforms** | Discord, Slack, Telegram |
-| **Web frameworks** | Next.js, Nuxt, Django, SvelteKit, NestJS, Express + React, FastAPI, Spring Boot |
-| **Mobile / desktop** | Expo, Flutter, Swift iOS, Kotlin Android, Tauri, Electron |
-| **Cloud / serverless** | AWS Lambda, Cloudflare Workers |
-| **Recording platforms** | Zoom, Riverside.fm |
-| **Browser / no-bundler** | Vanilla JavaScript |
-| **Low-code / automation** | n8n community nodes |
+| **Chat platforms** | Discord, Slack, Telegram | Nova prerecorded (`/v1/listen`) for attachments |
+| **Web frameworks** | Next.js, Nuxt, Django, SvelteKit, NestJS, Express + React, FastAPI, Spring Boot | Nova live (`/v1/listen`) for captions; Nova prerecorded for batch |
+| **Mobile / desktop** | Expo, Flutter, Swift iOS, Kotlin Android, Tauri, Electron | Nova live (`/v1/listen`); Flux if the app is a voice agent |
+| **Cloud / serverless** | AWS Lambda, Cloudflare Workers | Nova prerecorded (`/v1/listen`) — best fit for request/response |
+| **Recording platforms** | Zoom, Riverside.fm | Nova prerecorded (`/v1/listen`) |
+| **Browser / no-bundler** | Vanilla JavaScript | Nova live (`/v1/listen`) via the Browser SDK |
+| **LLM frameworks** | LangChain, LlamaIndex, Vercel AI SDK | Nova or Flux depending on streaming vs batch |
+| **Low-code / automation** | n8n community nodes | Nova (`/v1/listen`) for event-driven transcription |
 
 ## Install the related SDK skills
 

--- a/skills/recipes/SKILL.md
+++ b/skills/recipes/SKILL.md
@@ -42,11 +42,13 @@ recipes/{language}/{product}/{version}/{recipe}/
 
 | Product | Recipe examples |
 |---|---|
-| Speech-to-Text (v1) | transcribe-url, transcribe-file, paragraphs, diarize, smart-format, utterances, summarize, sentiment, topics, intents, detect-entities, detect-language, redact, search, keywords, streaming |
-| Speech-to-Text (v2 / Flux) | streaming transcription with conversational turn detection |
+| Speech-to-Text — Nova (`/v1/listen`) | transcribe-url, transcribe-file, paragraphs, diarize, smart-format, utterances, summarize, sentiment, topics, intents, detect-entities, detect-language, redact, search, keywords, streaming |
+| Speech-to-Text — Flux (`/v2/listen`) | streaming conversational transcription, EOT / eager-EOT, mid-session `Configure`, keyterms |
 | Text-to-Speech | generate-audio, stream-audio, websocket-streaming, select-model, select-encoding |
 | Audio Intelligence | summarize, sentiment, topics, intents, entities |
 | Voice Agents | connect, custom-llm, custom-tts, function-calling |
+
+Nova is the general-purpose STT family; Flux is designed for conversational audio and voice agents. Both are actively maintained — see the `api` skill's "Nova vs Flux" section for the decision guide.
 
 ## Languages
 

--- a/skills/recipes/SKILL.md
+++ b/skills/recipes/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: recipes
+description: >
+  Find focused, runnable Deepgram recipes for a specific feature × language. Use whenever
+  someone wants a minimal working code snippet for ONE feature (transcribe URL, diarize,
+  smart-format, voice agent connect, etc.) rather than a full starter app. Recipes are
+  under 50 lines, read DEEPGRAM_API_KEY from env, and ship with a runnable example_test.
+  Covers Python, JavaScript, Go, .NET, Java, Rust, and the Deepgram CLI.
+---
+
+# Deepgram Recipes
+
+Agent-maintained micro-recipes showing how to use every Deepgram SDK feature across every supported language. Each recipe is a focused, runnable snippet — not a full app.
+
+## When to use recipes
+
+- You know the product and feature; you want the shortest working code
+- You want `example.py` / `example.js` / `example.go` / etc. you can copy into your project
+- You want a language-specific answer to "how do I call `{feature}` with the Deepgram SDK?"
+
+**Use a different skill when:**
+- You want a full starter app with a web UI, deploy config, etc. → `starters` skill
+- You want integration with a third-party platform (Twilio, LiveKit, Vercel AI SDK, Discord, etc.) → `examples` skill
+- You want the full API contract (params, responses, message shapes) → `api` skill
+
+## Browse recipes
+
+Repository: <https://github.com/deepgram/recipes>
+
+Coverage matrix: <https://github.com/deepgram/recipes/blob/main/COVERAGE.md>
+
+## Recipe structure
+
+```
+recipes/{language}/{product}/{version}/{recipe}/
+  example.{ext}       # runnable, < 50 lines, reads DEEPGRAM_API_KEY from env
+  example_test.{ext}  # runs the example as a subprocess, asserts output
+  README.md           # feature explanation, params, sample output, how to run
+```
+
+## Products covered
+
+| Product | Recipe examples |
+|---|---|
+| Speech-to-Text (v1) | transcribe-url, transcribe-file, paragraphs, diarize, smart-format, utterances, summarize, sentiment, topics, intents, detect-entities, detect-language, redact, search, keywords, streaming |
+| Speech-to-Text (v2 / Flux) | streaming transcription with conversational turn detection |
+| Text-to-Speech | generate-audio, stream-audio, websocket-streaming, select-model, select-encoding |
+| Audio Intelligence | summarize, sentiment, topics, intents, entities |
+| Voice Agents | connect, custom-llm, custom-tts, function-calling |
+
+## Languages
+
+Python, JavaScript, Go, .NET, Java, Rust, plus the Deepgram CLI (`dg` / `deepctl`).
+
+## Install the related SDK skills
+
+For language-idiomatic patterns beyond a single recipe (full quick-starts, common patterns, gotchas), install the SDK-specific skills:
+
+```bash
+npx skills add deepgram/deepgram-python-sdk     # Python
+npx skills add deepgram/deepgram-js-sdk         # JavaScript / TypeScript
+npx skills add deepgram/deepgram-java-sdk       # Java
+npx skills add deepgram/deepgram-go-sdk         # Go
+npx skills add deepgram/deepgram-rust-sdk       # Rust
+npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
+npx skills add deepgram/deepgram-swift-sdk      # Swift
+npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
+npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
+```
+
+## Related Deepgram skills
+
+- `api` — consolidated REST + WebSocket API reference
+- `examples` — third-party platform integrations (Twilio, LiveKit, LangChain, etc.)
+- `starters` — runnable starter apps (framework × feature matrix)
+- `docs` — documentation finder
+- `setup-mcp` — Deepgram MCP server installation

--- a/skills/starters/SKILL.md
+++ b/skills/starters/SKILL.md
@@ -86,3 +86,17 @@ Get an API key at <https://console.deepgram.com>.
 | **ruby** | [repo](https://github.com/deepgram-starters/ruby-transcription) | [repo](https://github.com/deepgram-starters/ruby-live-transcription) | [repo](https://github.com/deepgram-starters/ruby-text-to-speech) | [repo](https://github.com/deepgram-starters/ruby-live-text-to-speech) | [repo](https://github.com/deepgram-starters/ruby-text-intelligence) | [repo](https://github.com/deepgram-starters/ruby-voice-agent) | [repo](https://github.com/deepgram-starters/ruby-flux) |
 | **php** | [repo](https://github.com/deepgram-starters/php-transcription) | [repo](https://github.com/deepgram-starters/php-live-transcription) | [repo](https://github.com/deepgram-starters/php-text-to-speech) | [repo](https://github.com/deepgram-starters/php-live-text-to-speech) | [repo](https://github.com/deepgram-starters/php-text-intelligence) | [repo](https://github.com/deepgram-starters/php-voice-agent) | [repo](https://github.com/deepgram-starters/php-flux) |
 | **cpp** | [repo](https://github.com/deepgram-starters/cpp-transcription) | [repo](https://github.com/deepgram-starters/cpp-live-transcription) | [repo](https://github.com/deepgram-starters/cpp-text-to-speech) | [repo](https://github.com/deepgram-starters/cpp-live-text-to-speech) | [repo](https://github.com/deepgram-starters/cpp-text-intelligence) | [repo](https://github.com/deepgram-starters/cpp-voice-agent) | [repo](https://github.com/deepgram-starters/cpp-flux) |
+
+## Need something more specific?
+
+- **Focused feature snippets** (one feature, one language, < 50 lines) → `recipes` skill → <https://github.com/deepgram/recipes>
+- **Third-party integrations** (Twilio, LiveKit, LangChain, Vercel AI SDK, Discord, etc.) → `examples` skill → <https://github.com/deepgram/examples>
+- **SDK-specific code skills** (idiomatic imports, async patterns, gotchas) → `npx skills add deepgram/deepgram-{lang}-sdk` — see the `api` skill for the full list of 9 SDKs.
+
+## Related Deepgram skills
+
+- `api` — consolidated REST + WebSocket API reference
+- `recipes` — minimal runnable feature snippets per language
+- `examples` — full integration examples with third-party platforms
+- `docs` — documentation finder
+- `setup-mcp` — Deepgram MCP server installation

--- a/skills/starters/SKILL.md
+++ b/skills/starters/SKILL.md
@@ -15,13 +15,15 @@ Clone a working demo and start building. Every starter is a minimal, runnable ap
 
 What do you want to build?
 
-- **Transcribe a file** → `transcription` — send audio/video, get text back (REST)
-- **Transcribe a live stream** → `live-transcription` — real-time speech-to-text (WebSocket)
+- **Transcribe a file** → `transcription` — send audio/video, get text back (REST, Nova)
+- **Transcribe a live stream** → `live-transcription` — real-time speech-to-text (WebSocket, Nova)
 - **Generate speech** → `text-to-speech` — send text, get audio back (REST)
 - **Stream speech** → `live-text-to-speech` — real-time text-to-audio (WebSocket)
 - **Analyze text or audio** → `text-intelligence` — sentiment, topics, intents, summaries (REST)
-- **Build a voice agent** → `voice-agent` — conversational AI agent (WebSocket)
-- **Use Flux** → `flux` — Deepgram Flux (REST)
+- **Build a voice agent** → `voice-agent` — conversational AI agent (WebSocket, agent.deepgram.com)
+- **Conversational STT with turn detection** → `flux` — Deepgram Flux for voice agents and interactive assistants (WebSocket, `/v2/listen`)
+
+**Nova vs Flux for speech-to-text:** use `transcription` or `live-transcription` (Nova, `/v1/listen`) for general-purpose transcription, captions, and batch workloads. Use `flux` (Flux, `/v2/listen`) when you need built-in turn detection for conversational audio. See the `api` skill for a full comparison.
 
 ## 2. Pick Your Stack
 

--- a/template/SKILL.md
+++ b/template/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: template-skill
 description: Replace with description of the skill and when to use it.
+metadata:
+  internal: true
 ---
 
 # Insert instructions below


### PR DESCRIPTION
## Summary

Grow the central skills repo into a hub that cross-references the full Deepgram resource ecosystem: per-SDK language skills, micro-recipes, and third-party integration examples.

## New skills

| Skill | Points to |
|---|---|
| `recipes` | [deepgram/recipes](https://github.com/deepgram/recipes) — agent-maintained focused runnable recipes (< 50 lines each) |
| `examples` | [deepgram/examples](https://github.com/deepgram/examples) — ~40 third-party integration demos (Twilio, LiveKit, LangChain, etc.) |

Both skills describe when to use them vs `api`, `starters`, and the per-SDK skills — so agents routing between "I need a contract", "I need a snippet", "I need a starter", "I need an integration", "I need language-specific code" land in the right place.

## Updated skills

- **`api`** — added "SDK-Specific Skills" section with install commands for all 9 SDKs + related-skill table
- **`docs`** — added SDK install commands + related-skill list
- **`starters`** — cross-references `recipes`, `examples`, and SDK skills ("Need something more specific?")
- **`README.md`** — new skills in the table + prominent SDK-Specific Skills section

## API reference regenerated from latest specs

Fetched from `https://dpgr.am/openapi.yml` and `https://dpgr.am/asyncapi.yml` and regenerated `skills/api/references/*.md`.

Required two fixes to `scripts/generate-skills.ts`:

1. **Tag normalizer** — the new OpenAPI spec uses Fern-style `subpackage_*` tags (e.g. `subpackage_agent/v1/settings/think/models`). Added `normalizeTag(rawTag, path)` to map these back to the 8 existing domains (Listen, Speak, Read, Agent, Models, Projects, Auth, Self-Hosted). Without this, the script crashed writing filenames with `/` and `.` in them.

2. **AsyncAPI 2.6 support** — the spec is AsyncAPI 2.6 (publish/subscribe inside each channel). The script was written for 3.x (top-level `operations` with `action: send|receive`). Rewrote `extractChannels` / `extractMessages` to walk the 2.6 structure. This recovers all 3 WebSocket channels (listen v1, listen v2, speak v1, agent) that were missing from the 3.x-shaped extraction.

3. **Voice Agent server override** — the AsyncAPI spec declares only one global server (`wss://api.deepgram.com/`), but Voice Agent runs on `wss://agent.deepgram.com/v1/agent/converse`. Added `resolveChannelServer` as a downstream override. Upstream spec fix to be raised with Fern separately.

### Regen produces the same 8 reference files

| File | REST | WebSocket |
|---|---|---|
| `listen.md` | 1 | 2 (v1, v2) |
| `speak.md` | 1 | 1 |
| `agent.md` | 11 | 1 |
| `read.md` | 1 | 0 |
| `models.md` | 4 | 0 |
| `projects.md` | 26 | 0 |
| `auth.md` | 1 | 0 |
| `self-hosted.md` | 4 | 0 |

## How to install

```bash
npx skills add deepgram/skills
```

Sibling PRs in the 9 Deepgram SDK repos add a cross-reference pointing back to this skill collection.