### PR TITLE
docs: update SDK skill references to new deepgram-{lang}-{product} namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
 npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
 ```
 
-Each SDK ships 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) plus a maintainer skill.
+Each SDK ships 7 product skills named `deepgram-{lang}-{product}` plus a maintainer skill `deepgram-{lang}-maintaining-sdk`. Example names for the Python SDK:
+
+- `deepgram-python-speech-to-text`
+- `deepgram-python-text-to-speech`
+- `deepgram-python-text-intelligence`
+- `deepgram-python-audio-intelligence`
+- `deepgram-python-voice-agent`
+- `deepgram-python-conversational-stt`
+- `deepgram-python-management-api`
+- `deepgram-python-maintaining-sdk`
+
+The `deepgram-{lang}-` prefix keeps names globally unique so installing skills from multiple SDKs never overwrites another SDK's skills.
 
 This `deepgram/skills` repo covers product contracts (API reference, docs, starters, recipes, integrations, MCP). The SDK repos cover language-specific usage.
 

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -161,7 +161,7 @@ Migrating from Nova 3 to Flux? See the official [Nova 3 → Flux migration guide
 
 ## SDK-Specific Skills
 
-This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) and a maintainer skill.
+This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills named `deepgram-{lang}-{product}` (e.g. `deepgram-python-speech-to-text`, `deepgram-js-voice-agent`) plus a maintainer skill `deepgram-{lang}-maintaining-sdk`. The `deepgram-{lang}-` prefix avoids collisions when you install skills from multiple SDKs.
 
 ```bash
 # Install all skills from a specific SDK
@@ -175,8 +175,9 @@ npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
 npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
 npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
 
-# Or install a specific product skill from one SDK
-npx skills add deepgram/deepgram-python-sdk --skill using-speech-to-text
+# Or install a specific product skill from one SDK (note the deepgram-{lang}- prefix)
+npx skills add deepgram/deepgram-python-sdk --skill deepgram-python-speech-to-text
+npx skills add deepgram/deepgram-js-sdk     --skill deepgram-js-voice-agent
 ```
 
 ## Related Deepgram skills


### PR DESCRIPTION
## Summary

The 9 Deepgram SDK repos now publish their skills under the `deepgram-{lang}-{product}` namespace (e.g. `deepgram-python-speech-to-text` instead of `using-speech-to-text`). This avoids name collisions when installing skills from multiple SDKs.

## Why

Previously every SDK published identically-named product skills:

```
deepgram-python-sdk  → .agents/skills/using-speech-to-text/SKILL.md
deepgram-js-sdk      → .agents/skills/using-speech-to-text/SKILL.md
deepgram-java-sdk    → .agents/skills/using-speech-to-text/SKILL.md
…
```

Installing skills from Python and then JS would overwrite the first with the second — users could only have one SDK's skills at a time.

## Changes in this PR

- **`README.md`** — replace the hard-coded skill-name list with the namespace pattern + a full example set for the Python SDK.
- **`skills/api/SKILL.md`** — document the `deepgram-{lang}-` prefix in the SDK-Specific Skills section; update the `--skill` install example from `using-speech-to-text` → `deepgram-python-speech-to-text`.

## Sibling PRs (one per SDK)

Each SDK's `lo/add-agent-skills` PR now includes a follow-up rename commit:

| SDK | PR | Rename commit |
|---|---|---|
| python | [#695](https://github.com/deepgram/deepgram-python-sdk/pull/695) | adds `chore: namespace skill names with deepgram-python-` |
| js | [#486](https://github.com/deepgram/deepgram-js-sdk/pull/486) | adds `chore: namespace skill names with deepgram-js-` |
| java | [#39](https://github.com/deepgram/deepgram-java-sdk/pull/39) | adds `chore: namespace skill names with deepgram-java-` |
| go | [#325](https://github.com/deepgram/deepgram-go-sdk/pull/325) | adds `chore: namespace skill names with deepgram-go-` |
| rust | [#153](https://github.com/deepgram/deepgram-rust-sdk/pull/153) | adds `chore: namespace skill names with deepgram-rust-` |
| swift | [#2](https://github.com/deepgram/deepgram-swift-sdk/pull/2) | adds `chore: namespace skill names with deepgram-swift-` |
| kotlin | [#2](https://github.com/deepgram/deepgram-kotlin-sdk/pull/2) | adds `chore: namespace skill names with deepgram-kotlin-` |
| dotnet | [#401](https://github.com/deepgram/deepgram-dotnet-sdk/pull/401) | adds `chore: namespace skill names with deepgram-dotnet-` |
| browser | [#12](https://github.com/deepgram/deepgram-browser-sdk/pull/12) | adds `chore: namespace skill names with deepgram-browser-` |

Each renames 8 folders, updates every SKILL.md's frontmatter `name`, and updates all sibling-skill cross-references.