### PR TITLE
docs: update SDK skill references to new deepgram-{lang}-{product} namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
 npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
 ```
 
-Each SDK ships 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) plus a maintainer skill.
+Each SDK ships 7 product skills named `deepgram-{lang}-{product}` plus a maintainer skill `deepgram-{lang}-maintaining-sdk`. Example names for the Python SDK:
+
+- `deepgram-python-speech-to-text`
+- `deepgram-python-text-to-speech`
+- `deepgram-python-text-intelligence`
+- `deepgram-python-audio-intelligence`
+- `deepgram-python-voice-agent`
+- `deepgram-python-conversational-stt`
+- `deepgram-python-management-api`
+- `deepgram-python-maintaining-sdk`
+
+The `deepgram-{lang}-` prefix keeps names globally unique so installing skills from multiple SDKs never overwrites another SDK's skills.
 
 This `deepgram/skills` repo covers product contracts (API reference, docs, starters, recipes, integrations, MCP). The SDK repos cover language-specific usage.
 

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -161,7 +161,7 @@ Migrating from Nova 3 to Flux? See the official [Nova 3 → Flux migration guide
 
 ## SDK-Specific Skills
 
-This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) and a maintainer skill.
+This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills named `deepgram-{lang}-{product}` (e.g. `deepgram-python-speech-to-text`, `deepgram-js-voice-agent`) plus a maintainer skill `deepgram-{lang}-maintaining-sdk`. The `deepgram-{lang}-` prefix avoids collisions when you install skills from multiple SDKs.
 
 ```bash
 # Install all skills from a specific SDK
@@ -175,8 +175,9 @@ npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
 npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
 npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
 
-# Or install a specific product skill from one SDK
-npx skills add deepgram/deepgram-python-sdk --skill using-speech-to-text
+# Or install a specific product skill from one SDK (note the deepgram-{lang}- prefix)
+npx skills add deepgram/deepgram-python-sdk --skill deepgram-python-speech-to-text
+npx skills add deepgram/deepgram-js-sdk     --skill deepgram-js-voice-agent
 ```
 
 ## Related Deepgram skills


### PR DESCRIPTION
## Summary

- updates README and `skills/api/SKILL.md` to reference SDK skills using the new `deepgram-{lang}-{product}` naming pattern
- mirrors the renames already landed in each SDK repo

## Why

the old flat names (`using-speech-to-text` etc.) collide when you install skills from multiple SDKs in the same agent. the `deepgram-{lang}-` prefix keeps every skill name globally unique across all 9 SDK repos.

## Test plan

- [ ] examples in the README and `skills/api/SKILL.md` match what's actually in each `deepgram/deepgram-{lang}-sdk/.agents/skills/` tree today
- [ ] `npx skills add deepgram/deepgram-python-sdk --skill deepgram-python-speech-to-text` resolves