### PR TITLE
feat: aggregate SDK skills into the deepgram marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,15 @@
   "plugins": [
     {
       "name": "deepgram",
-      "description": "Deepgram skills for AI coding tools — API reference, documentation, starter apps, and MCP server setup",
+      "description": "Deepgram skills for AI coding tools — API reference, documentation, starter apps, recipes, integration examples, and MCP server setup",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/api",
         "./skills/docs",
         "./skills/starters",
+        "./skills/recipes",
+        "./skills/examples",
         "./skills/setup-mcp"
       ]
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,96 @@
         "./skills/examples",
         "./skills/setup-mcp"
       ]
+    },
+    {
+      "name": "deepgram-js-sdk",
+      "description": "Deepgram JavaScript and TypeScript SDK skills for speech-to-text, text-to-speech, voice agents, and audio intelligence",
+      "source": { "source": "github", "repo": "deepgram/deepgram-js-sdk" },
+      "strict": false,
+      "skills": [
+        ".agents/skills/deepgram-js-audio-intelligence",
+        ".agents/skills/deepgram-js-conversational-stt",
+        ".agents/skills/deepgram-js-management-api",
+        ".agents/skills/deepgram-js-speech-to-text",
+        ".agents/skills/deepgram-js-text-intelligence",
+        ".agents/skills/deepgram-js-text-to-speech",
+        ".agents/skills/deepgram-js-voice-agent"
+      ]
+    },
+    {
+      "name": "deepgram-python-sdk",
+      "description": "Deepgram Python SDK skills for speech-to-text, text-to-speech, voice agents, and audio intelligence",
+      "source": { "source": "github", "repo": "deepgram/deepgram-python-sdk" },
+      "strict": false,
+      "skills": [
+        ".agents/skills/deepgram-python-audio-intelligence",
+        ".agents/skills/deepgram-python-conversational-stt",
+        ".agents/skills/deepgram-python-management-api",
+        ".agents/skills/deepgram-python-speech-to-text",
+        ".agents/skills/deepgram-python-text-intelligence",
+        ".agents/skills/deepgram-python-text-to-speech",
+        ".agents/skills/deepgram-python-voice-agent"
+      ]
+    },
+    {
+      "name": "deepgram-java-sdk",
+      "description": "Deepgram Java SDK skills for speech-to-text, text-to-speech, voice agents, and audio intelligence",
+      "source": { "source": "github", "repo": "deepgram/deepgram-java-sdk" },
+      "strict": false,
+      "skills": [
+        ".agents/skills/deepgram-java-audio-intelligence",
+        ".agents/skills/deepgram-java-conversational-stt",
+        ".agents/skills/deepgram-java-management-api",
+        ".agents/skills/deepgram-java-speech-to-text",
+        ".agents/skills/deepgram-java-text-intelligence",
+        ".agents/skills/deepgram-java-text-to-speech",
+        ".agents/skills/deepgram-java-voice-agent"
+      ]
+    },
+    {
+      "name": "deepgram-go-sdk",
+      "description": "Deepgram Go SDK skills for speech-to-text, text-to-speech, voice agents, and audio intelligence",
+      "source": { "source": "github", "repo": "deepgram/deepgram-go-sdk" },
+      "strict": false,
+      "skills": [
+        ".agents/skills/deepgram-go-audio-intelligence",
+        ".agents/skills/deepgram-go-conversational-stt",
+        ".agents/skills/deepgram-go-management-api",
+        ".agents/skills/deepgram-go-speech-to-text",
+        ".agents/skills/deepgram-go-text-intelligence",
+        ".agents/skills/deepgram-go-text-to-speech",
+        ".agents/skills/deepgram-go-voice-agent"
+      ]
+    },
+    {
+      "name": "deepgram-rust-sdk",
+      "description": "Deepgram Rust SDK skills for speech-to-text, text-to-speech, voice agents, and audio intelligence",
+      "source": { "source": "github", "repo": "deepgram/deepgram-rust-sdk" },
+      "strict": false,
+      "skills": [
+        ".agents/skills/deepgram-rust-audio-intelligence",
+        ".agents/skills/deepgram-rust-conversational-stt",
+        ".agents/skills/deepgram-rust-management-api",
+        ".agents/skills/deepgram-rust-speech-to-text",
+        ".agents/skills/deepgram-rust-text-intelligence",
+        ".agents/skills/deepgram-rust-text-to-speech",
+        ".agents/skills/deepgram-rust-voice-agent"
+      ]
+    },
+    {
+      "name": "deepgram-dotnet-sdk",
+      "description": "Deepgram .NET SDK skills for speech-to-text, text-to-speech, voice agents, and audio intelligence",
+      "source": { "source": "github", "repo": "deepgram/deepgram-dotnet-sdk" },
+      "strict": false,
+      "skills": [
+        ".agents/skills/deepgram-dotnet-audio-intelligence",
+        ".agents/skills/deepgram-dotnet-conversational-stt",
+        ".agents/skills/deepgram-dotnet-management-api",
+        ".agents/skills/deepgram-dotnet-speech-to-text",
+        ".agents/skills/deepgram-dotnet-text-intelligence",
+        ".agents/skills/deepgram-dotnet-text-to-speech",
+        ".agents/skills/deepgram-dotnet-voice-agent"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -95,7 +95,22 @@ This gives you the following slash commands:
 - `/deepgram:api` — Deepgram API reference
 - `/deepgram:docs` — Find the right documentation
 - `/deepgram:starters` — Clone a starter app
+- `/deepgram:recipes` — Focused runnable recipes for one feature × one language
+- `/deepgram:examples` — Integration examples with third-party platforms
 - `/deepgram:setup-mcp` — Set up the Deepgram MCP server
+
+You can also install SDK-specific skill plugins from the same marketplace:
+
+```
+/plugin install deepgram-js-sdk@deepgram-agent-skills
+/plugin install deepgram-python-sdk@deepgram-agent-skills
+/plugin install deepgram-java-sdk@deepgram-agent-skills
+/plugin install deepgram-go-sdk@deepgram-agent-skills
+/plugin install deepgram-rust-sdk@deepgram-agent-skills
+/plugin install deepgram-dotnet-sdk@deepgram-agent-skills
+```
+
+Each SDK plugin installs the 7 language-idiomatic skills from that SDK's repository.
 
 # Creating a Skill
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
 npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
 ```
 
-Each SDK ships 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) plus a maintainer skill.
+Each SDK ships 7 product skills named `deepgram-{lang}-{product}` plus a maintainer skill `deepgram-{lang}-maintaining-sdk`. Example names for the Python SDK:
+
+- `deepgram-python-speech-to-text`
+- `deepgram-python-text-to-speech`
+- `deepgram-python-text-intelligence`
+- `deepgram-python-audio-intelligence`
+- `deepgram-python-voice-agent`
+- `deepgram-python-conversational-stt`
+- `deepgram-python-management-api`
+- `deepgram-python-maintaining-sdk`
+
+The `deepgram-{lang}-` prefix keeps names globally unique so installing skills from multiple SDKs never overwrites another SDK's skills.
 
 This `deepgram/skills` repo covers product contracts (API reference, docs, starters, recipes, integrations, MCP). The SDK repos cover language-specific usage.
 

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -161,7 +161,7 @@ Migrating from Nova 3 to Flux? See the official [Nova 3 → Flux migration guide
 
 ## SDK-Specific Skills
 
-This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills (`using-speech-to-text`, `using-text-to-speech`, `using-text-intelligence`, `using-audio-intelligence`, `using-voice-agent`, `using-conversational-stt`, `using-management-api`) and a maintainer skill.
+This `api` skill covers the product contracts (endpoints, query params, message shapes) that are identical across SDKs. For **language-idiomatic code** — imports, async patterns, builder APIs, common errors — install the SDK-specific skills. Each Deepgram SDK publishes 7 product skills named `deepgram-{lang}-{product}` (e.g. `deepgram-python-speech-to-text`, `deepgram-js-voice-agent`) plus a maintainer skill `deepgram-{lang}-maintaining-sdk`. The `deepgram-{lang}-` prefix avoids collisions when you install skills from multiple SDKs.
 
 ```bash
 # Install all skills from a specific SDK
@@ -175,8 +175,9 @@ npx skills add deepgram/deepgram-kotlin-sdk     # Kotlin
 npx skills add deepgram/deepgram-dotnet-sdk     # C# / .NET
 npx skills add deepgram/deepgram-browser-sdk    # Browser TypeScript
 
-# Or install a specific product skill from one SDK
-npx skills add deepgram/deepgram-python-sdk --skill using-speech-to-text
+# Or install a specific product skill from one SDK (note the deepgram-{lang}- prefix)
+npx skills add deepgram/deepgram-python-sdk --skill deepgram-python-speech-to-text
+npx skills add deepgram/deepgram-js-sdk     --skill deepgram-js-voice-agent
 ```
 
 ## Related Deepgram skills


### PR DESCRIPTION
## Summary

- aggregates all 6 core SDK skills (JS, Python, Java, Go, Rust, .NET) into the deepgram/skills marketplace via cross-repo `source` entries
- adds the missing `examples` and `recipes` skills to the existing `deepgram` plugin
- documents the SDK plugin installs in the Claude Code section of the README

## Why

before this PR, only `deepgram-js-sdk` was indexed on skills.sh. the other 5 SDK repos exist on disk with skills under `.agents/skills/` but no one had installed them via `npx skills add` so the registry never picked them up.

with the namespace work in #5, skill names are now globally unique across SDKs, so aggregating them in one marketplace is safe. after this lands, `/plugin marketplace add deepgram/skills` exposes 7 plugins: the core `deepgram` plugin plus one per SDK.

## Shape

each SDK plugin uses an explicit `skills` array pointing at `.agents/skills/<skill>` paths inside the SDK repo, since the SDKs don't carry their own `.claude-plugin/plugin.json` (they rely on default skill discovery, which doesn't pick up `.agents/skills/`).

```json
{
  "name": "deepgram-js-sdk",
  "source": { "source": "github", "repo": "deepgram/deepgram-js-sdk" },
  "skills": [
    ".agents/skills/deepgram-js-audio-intelligence",
    ".agents/skills/deepgram-js-conversational-stt",
    ...
  ]
}
```

## Test plan

- [ ] `/plugin marketplace add deepgram/skills` resolves all 7 plugin entries
- [ ] `/plugin install deepgram-js-sdk@deepgram-agent-skills` pulls the JS skills, repeat for python/java/go/rust/dotnet
- [ ] `npx skills add deepgram/skills` still works for the core `deepgram` plugin
- [ ] existing `/deepgram:*` slash commands still resolve, plus new `/deepgram:examples` and `/deepgram:recipes`

## Notes

- `npx skills` doesn't currently follow remote `source` objects in `marketplace.json` ([plugin-manifest.ts#L77-L96](https://github.com/vercel-labs/skills/blob/main/src/plugin-manifest.ts#L77-L96)). users still need `npx skills add deepgram/<sdk-repo>` directly per SDK to get those via the npx flow. raised separately with vercel-labs.
- kotlin and swift SDKs are ready, out of scope here, can land in a follow-up
- browser SDK is still private, not included

## Related

- stacks on #5