### PR TITLE
feat: add capability-named entry skills (speech-to-text, text-to-speech, voice-agent)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,10 +11,13 @@
   "plugins": [
     {
       "name": "deepgram",
-      "description": "Deepgram skills for AI coding tools — API reference, documentation, starter apps, recipes, integration examples, and MCP server setup",
+      "description": "Deepgram skills for AI coding tools — speech-to-text, text-to-speech, and voice-agent on-ramps, API reference, documentation, starter apps, recipes, integration examples, and MCP server setup",
       "source": "./",
       "strict": false,
       "skills": [
+        "./skills/speech-to-text",
+        "./skills/text-to-speech",
+        "./skills/voice-agent",
         "./skills/api",
         "./skills/docs",
         "./skills/starters",

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Some skills are hand-written, others are generated from Deepgram's [OpenAPI](htt
 
 | Skill | Description |
 |-------|-------------|
+| [speech-to-text](./skills/speech-to-text) | Start here for transcription: Nova on `/v1/listen` or Flux STT on `/v2/listen`, a first request, and where to go next |
+| [text-to-speech](./skills/text-to-speech) | Start here for synthesis: Aura on `/v1/speak` or Flux TTS on `/v2/speak`, a first request, and where to go next |
+| [voice-agent](./skills/voice-agent) | Start here for a voice agent: the Voice Agent API over one WebSocket, function calling, telephony wiring, and when to use an orchestrator instead |
 | [api](./skills/api) | Full API reference for all Deepgram REST and WebSocket APIs, generated from OpenAPI and AsyncAPI specs |
 | [docs](./skills/docs) | Find the right Deepgram documentation for any task |
 | [starters](./skills/starters) | Clone a ready-to-run demo app in your language and start building — 13 frameworks, 8 features |
@@ -75,7 +78,17 @@ This `deepgram/skills` repo covers product contracts (API reference, docs, start
 
 ## Any AI coding tool
 
-Works with Claude Code, Cursor, Windsurf, GitHub Copilot, Gemini CLI, and [30+ others](https://github.com/vercel-labs/skills):
+Works with Claude Code, Cursor, Windsurf, GitHub Copilot, Gemini CLI, and [30+ others](https://github.com/vercel-labs/skills).
+
+Install the skill for what you are building:
+
+```bash
+npx skills add deepgram/skills --skill speech-to-text
+npx skills add deepgram/skills --skill text-to-speech
+npx skills add deepgram/skills --skill voice-agent
+```
+
+Or install every skill in this repository:
 
 ```bash
 npx skills add deepgram/skills
@@ -97,6 +110,9 @@ Then install the Deepgram plugin:
 
 This gives you the following slash commands:
 
+- `/deepgram:speech-to-text` — Start here for transcription
+- `/deepgram:text-to-speech` — Start here for synthesis
+- `/deepgram:voice-agent` — Start here for a voice agent
 - `/deepgram:api` — Deepgram API reference
 - `/deepgram:docs` — Find the right documentation
 - `/deepgram:starters` — Clone a starter app

--- a/skills/speech-to-text/SKILL.md
+++ b/skills/speech-to-text/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: speech-to-text
+description: >
+  Start here for Deepgram speech-to-text. Use when a task says "speech to text", "STT",
+  "transcribe", "transcription", "live transcription", "captions", "diarization", "nova-3",
+  "Flux", "turn detection", or "end of turn". Picks the model family (Nova on /v1/listen for
+  general transcription, Flux STT on /v2/listen for conversational audio with built-in turn
+  detection), gets a first request working, and routes to the api, docs, recipes, starters,
+  examples, and per-language SDK skills for everything else.
+---
+
+# Deepgram Speech-to-Text
+
+Deepgram transcribes audio with two model families on two endpoints. Pick the family first; the endpoint, the parameters, and the message shapes all follow from that choice. This skill gets a first request working and names the skill to open next. It does not repeat the full parameter reference; that lives in the `api` skill.
+
+## Pick the model family first
+
+| | Nova | Flux STT |
+|---|---|---|
+| Model names | `nova-3` (alias of `nova-3-general`), `nova-3-medical` | `flux-general-en` (English), `flux-general-multi` (10 languages) |
+| Endpoint | `/v1/listen`, REST and WebSocket | `/v2/listen`, WebSocket only |
+| Output | A transcript stream | `TurnInfo` events carrying turn state and a transcript per turn |
+| Turn detection | None built in; you use endpointing and your own logic | Built in: `StartOfTurn`, `EagerEndOfTurn`, `TurnResumed`, `EndOfTurn` |
+| Formatting and analysis | `smart_format`, `diarize_model`, `summarize`, `sentiment`, `topics`, `intents`, redaction | Word timestamps, `numerals`, number redaction, `keyterm`; no smart formatting, no diarization |
+| Language | `language=<code>`, or `language=multi` for code-switching | The model name selects the language; `language_hint` biases `flux-general-multi` |
+
+Decision rule:
+
+- Choose Nova when you transcribe recorded files, generate captions or subtitles, need speaker labels, need summaries or sentiment, or stream audio where your own code decides when a phrase ends.
+- Choose Flux STT when a person is talking to software and the software must know when they stopped: voice agents, phone assistants, IVR, agent assist. Flux has no prerecorded mode.
+- Choose neither when you want Deepgram to also run the language model and speak the reply. That is the Voice Agent API, served from a separate host, `agent.deepgram.com`. Open the `voice-agent` skill.
+
+## First request: Nova on a prerecorded file
+
+Create a key at https://console.deepgram.com and export it as `DEEPGRAM_API_KEY`. The key goes in the `Authorization` header with the `Token` scheme. Always pass `model`; without it the API falls back to `base`.
+
+```bash
+curl -s -X POST 'https://api.deepgram.com/v1/listen?model=nova-3&smart_format=true' \
+  -H "Authorization: Token $DEEPGRAM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://dpgr.am/spacewalk.wav"}'
+```
+
+The transcript is at `results.channels[0].alternatives[0].transcript`. To send a local file instead, set `Content-Type` to the audio type (for example `audio/wav`) and pass `--data-binary @file.wav` with no JSON body.
+
+Nova options you will reach for, all query parameters on `/v1/listen`:
+
+- `smart_format=true` adds punctuation, paragraphs, and number formatting. It turns on `punctuate`, so do not set both.
+- `diarize_model=latest` labels speakers. It replaces the deprecated `diarize=true`; a request that sets both is rejected. Streaming accepts `latest` and `v1` only.
+- `language=multi` transcribes code-switched speech across the ten Nova-3 multilingual languages. Any single language code works too; the default is `en`.
+- `keyterm=<term>` boosts up to 100 terms on Nova-3. Repeat the parameter once per term. Commas, semicolons, and `term:weight` are not rejected; the API treats the whole value as one literal term and boosts nothing.
+- `summarize=v2`, `sentiment=true`, `topics=true`, and `intents=true` add audio intelligence. They run on prerecorded English audio only.
+- Live streaming uses `wss://api.deepgram.com/v1/listen?model=nova-3`, the same `Authorization` header, and binary audio frames. During silence send `{"type":"KeepAlive"}` as a text frame every 3 to 5 seconds; the connection closes after 10 seconds without audio. Finish with `{"type":"CloseStream"}`.
+
+## Flux STT: conversational audio with turn detection
+
+Connect over WebSocket. Flux has no REST path.
+
+```
+wss://api.deepgram.com/v2/listen?model=flux-general-en&encoding=linear16&sample_rate=16000
+```
+
+Send the same `Authorization: Token` header. Audio must be mono. For raw audio (`linear16`, `linear32`, `mulaw`, `alaw`, `opus`, `ogg-opus`) `encoding` and `sample_rate` are required; for WAV, Ogg, or WebM containers omit both. Send 80 ms chunks.
+
+The server sends `Connected`, then a stream of `TurnInfo` messages. Each carries `event`, `turn_index`, `transcript`, `words` with timestamps, and `end_of_turn_confidence`. The `event` values:
+
+- `Update`: roughly every 0.25 s of audio while a turn is in progress.
+- `StartOfTurn`: the speaker began. Use it to interrupt your agent (barge-in).
+- `EndOfTurn`: the speaker finished. Send the transcript to your language model. It carries `trigger`: `model`, `manual`, or `timeout`.
+- `EagerEndOfTurn` and `TurnResumed`: emitted only when you set `eager_eot_threshold`. Start drafting a reply on the first; cancel it on the second.
+
+Three query parameters tune turn detection, and all three can change mid-stream:
+
+| Parameter | Range | Default | Effect |
+|---|---|---|---|
+| `eot_threshold` | 0.5 to 1.0 | 0.7 | Confidence needed for `EndOfTurn`. `1.0` suppresses model detection. |
+| `eager_eot_threshold` | 0.3 to 0.9 | unset | Enables `EagerEndOfTurn`. Lower values fire earlier with more false starts. |
+| `eot_timeout_ms` | 500 to 60000 | 5000 | Silence that forces `EndOfTurn` regardless of confidence. |
+
+Client control messages, each a JSON text frame:
+
+- `{"type":"Configure","thresholds":{"eot_threshold":0.8},"keyterms":["Deepgram"]}` changes thresholds, keyterms, or `language_hints` without reconnecting. Omitted fields keep their values; a `keyterms` array replaces the whole list. The reply is `ConfigureSuccess` or `ConfigureFailure`.
+- `{"type":"ForceEndTurn"}` (added August 28, 2026) ends the current turn on your own signal: a push-to-talk release, a DTMF tone, a send button. Flux emits `EndOfTurn` with `"trigger":"manual"`. With no active turn the message is ignored and a `Warning` with code `FORCE_END_TURN_NO_ACTIVE_TURN` comes back. Set `eot_threshold=1.0` to drive every turn yourself.
+- `{"type":"CloseStream"}` closes the stream.
+
+For non-English or mixed-language calls use `model=flux-general-multi`, optionally with repeated `language_hint=<code>` parameters (for example `language_hint=en&language_hint=es`). Without hints the model detects the language itself. `TurnInfo` then includes `languages` and `languages_hinted`.
+
+## Common mistakes
+
+1. `Authorization: Bearer <api key>` returns 401. API keys use `Authorization: Token <key>`. `Bearer` is only for the short-lived JWT that `POST /v1/auth/grant` issues.
+2. A 403 with `{"err_code":"INSUFFICIENT_PERMISSIONS","err_msg":"Project does not have access to the requested model."}` comes back both for a misspelled model name and for a real model the project cannot use. Check the spelling before asking for access (verified live 2026-09-03: a made-up model name on `/v1/listen` returned exactly this body). `GET https://api.deepgram.com/v1/models` lists the public catalog; `GET /v1/projects/{project_id}/models` lists your project's models. There is no model named `nova-3-conversational`; conversational audio is Flux, `flux-general-en`. The public catalog did not list the Flux model names when checked on 2026-09-03; the Flux docs are the source for those.
+3. Flux on `/v1/listen` does not work, and `model=flux` is not a valid value. Use `/v2/listen` with `flux-general-en` or `flux-general-multi`.
+4. `language=en` or `language=multi` on Flux is wrong. The model name selects the language. `language_hint` is accepted only by `flux-general-multi` and returns 400 on any other model.
+5. Setting `encoding` or `sample_rate` for containerized audio (WAV, Ogg, WebM) causes errors or garbled output. Omit both and let the container declare the format.
+6. `ForceEndTurn` on `/v1/listen` returns an error; it exists only on Flux.
+7. `smart_format`, `diarize`, and the intelligence parameters are not available on `/v2/listen`. Speaker labels and summaries are a Nova job.
+8. A `KeepAlive` sent as a binary frame is mishandled. Send control messages as text frames and audio as binary frames.
+
+## Pricing
+
+Deepgram bills speech-to-text per minute of audio. Figures change, so read them at https://deepgram.com/pricing rather than from any skill.
+
+## Use a different skill when
+
+- You need every parameter, response schema, or message field: `api` skill, file `references/listen.md`.
+- You want the documentation page for a topic: `docs` skill. The pages this skill leans on are listed under Sources.
+- You want a runnable app with a UI: `starters` skill (the `transcription`, `live-transcription`, and `flux` features).
+- You want a one-feature snippet under 50 lines: `recipes` skill, https://github.com/deepgram/recipes.
+- You are wiring Deepgram into Twilio, LiveKit, Pipecat, LangChain, or another platform: `examples` skill.
+- You want language-idiomatic SDK code: install `deepgram-{js,python,java,go,rust,dotnet}-speech-to-text` for Nova and `deepgram-{lang}-conversational-stt` for Flux from the matching SDK repository (`npx skills add deepgram/deepgram-python-sdk`, and so on).
+- You want text-to-speech or a full voice agent: the `text-to-speech` or `voice-agent` skill.
+- You want the docs queryable from your coding tool: `setup-mcp` skill.
+
+## Sources
+
+- Getting started: https://developers.deepgram.com/docs/stt/getting-started
+- Nova prerecorded: https://developers.deepgram.com/docs/pre-recorded-audio
+- Nova live streaming: https://developers.deepgram.com/docs/live-streaming-audio and https://developers.deepgram.com/docs/audio-keep-alive
+- Models and languages: https://developers.deepgram.com/docs/models-languages-overview
+- Multilingual code switching: https://developers.deepgram.com/docs/multilingual-code-switching
+- Smart Format, diarization, keyterms: https://developers.deepgram.com/docs/smart-format, https://developers.deepgram.com/docs/diarization, https://developers.deepgram.com/docs/keyterm
+- Audio intelligence: https://developers.deepgram.com/docs/audio-intelligence and https://developers.deepgram.com/docs/stt-intelligence-feature-overview
+- Flux quickstart: https://developers.deepgram.com/docs/flux/quickstart
+- Flux compared with Nova-3: https://developers.deepgram.com/docs/flux/flux-nova-3-comparison
+- Nova-3 to Flux migration: https://developers.deepgram.com/docs/flux/nova-3-migration
+- Flux state machine: https://developers.deepgram.com/docs/flux/state
+- Flux control messages: https://developers.deepgram.com/docs/flux/configure, https://developers.deepgram.com/docs/flux/force-end-turn, https://developers.deepgram.com/docs/flux/close-stream
+- ForceEndTurn release note: https://developers.deepgram.com/changelog/2026/8/28
+- Flux multilingual: https://developers.deepgram.com/docs/flux/language-prompting
+- Authentication: https://developers.deepgram.com/guides/fundamentals/authenticating and https://developers.deepgram.com/guides/fundamentals/token-based-authentication
+- Models endpoint: https://developers.deepgram.com/guides/fundamentals/model-metadata
+- Error codes: https://developers.deepgram.com/docs/errors
+- Voice Agent host (agent.deepgram.com): https://developers.deepgram.com/docs/build-a-voice-agent
+- API reference: https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded, https://developers.deepgram.com/reference/speech-to-text/listen-streaming, https://developers.deepgram.com/reference/speech-to-text/listen-flux

--- a/skills/text-to-speech/SKILL.md
+++ b/skills/text-to-speech/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: text-to-speech
+description: >
+  Turn text into spoken audio with Deepgram. Use when someone asks for text-to-speech, TTS,
+  speech synthesis, a synthetic voice, a voice for a voice agent, an IVR prompt, or an audio
+  version of some text, and whenever they mention Aura, Aura-2, Flux TTS, /v1/speak or /v2/speak.
+  Trigger phrases: "text to speech", "TTS", "speak endpoint", "generate speech", "synthesize
+  audio", "read this aloud", "which Deepgram voice", "Aura vs Flux TTS", "TTS with barge-in".
+  Gets an agent to a correct first request, then routes to the api, docs, starters,
+  recipes, examples, setup-mcp and per-language SDK text-to-speech skills.
+---
+
+# Deepgram Text-to-Speech
+
+Deepgram serves two text-to-speech families on separate endpoints, and the voices do not overlap.
+Aura voices run only on `/v1/speak`. Flux TTS voices run only on `/v2/speak`. `/v2/speak` is an
+additional endpoint. `/v1/speak` is unchanged and remains supported.
+
+## Pick the family first
+
+| Need | Family | Endpoint |
+|---|---|---|
+| One-shot audio: a file, an IVR prompt, a notification | Aura | `POST https://api.deepgram.com/v1/speak` |
+| Any language other than English | Aura-2 | `/v1/speak` |
+| Low-latency stream with manual flush control | Aura | `wss://api.deepgram.com/v1/speak` |
+| A voice agent that streams LLM output and must survive barge-in | Flux TTS | `wss://api.deepgram.com/v2/speak` |
+| Pre-rendered audio in a Flux voice | Flux TTS batch | `POST https://api.deepgram.com/v2/speak` |
+
+Rule of thumb: Aura for one-shot and non-English, Flux TTS for voice agents. Flux TTS voices are
+English only today; for other languages use Aura-2.
+
+## First request: Aura over REST
+
+```bash
+curl --request POST \
+  --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&container=wav" \
+  --header "Authorization: Token $DEEPGRAM_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{"text": "Hello, how can I help you today?"}' \
+  --output hello.wav \
+  --fail-with-body --silent || echo "Request failed"
+```
+
+What to expect:
+
+- A 2xx body is binary audio. Errors are JSON. Check the HTTP status before you parse.
+- Options go on the query string. The JSON body carries only `text`.
+- With no `encoding`, REST returns `mp3`. For WAV send `encoding=linear16&container=wav`. Other REST
+  encodings: `opus`, `flac`, `aac`, `mulaw`, `alaw`, with `container`, `bit_rate`, `sample_rate`.
+- If you omit `model`, `/v1/speak` uses `aura-asteria-en`, an Aura-1 voice. Always set `model`.
+- Aura-2 `speed` accepts `0.7` to `1.5` and works for English and Spanish voices only.
+
+## Aura over WebSocket
+
+Connect to `wss://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate=24000`
+with the same `Authorization: Token` header. Send JSON text frames: `{"type":"Speak","text":"..."}` to
+queue text, `{"type":"Flush"}` to force audio out, `{"type":"Clear"}` to drop the buffer, and
+`{"type":"Close"}` to end. Audio arrives as binary frames; `Metadata`, `Flushed`, `Cleared`, and
+`Warning` arrive as JSON. Send `Flush` when the LLM finishes a response. `Flush` is limited to 20
+sends per 60 seconds. Streaming output is raw `linear16` (default), `mulaw`, or `alaw` only.
+
+## Flux TTS for voice agents
+
+Connect to `wss://api.deepgram.com/v2/speak?model=flux-haley-en`. `model` is required and must be a
+`flux-*` voice. There is no default, and an Aura string is rejected.
+
+A session is a sequence of turns. Stream tokens in, then end the turn:
+
+```json
+{"type": "Speak", "text": "Sure, I can "}
+{"type": "Speak", "text": "help you cancel your subscription."}
+{"type": "Flush"}
+```
+
+- Audio starts streaming before you `Flush`. `Flush` ends the turn; the server then sends `Flushed` and
+  `SpeechMetadata` with billing and timing. Treat `SpeechMetadata` as the end of the turn; `Flushed` arrives earlier.
+- The server assigns `speech_id` per turn in `SpeechStarted` and `SpeechMetadata`. Never send one.
+- On barge-in, stop local playback first, then send
+  `{"type":"Interrupt","playback_offset":{"type":"time_ms","value":2340}}`. `SpeechInterrupted` returns
+  `text_spoken` and `text_remaining`; feed `text_spoken` back into the LLM context. Without a
+  `playback_offset` the split is omitted.
+- `{"type":"Configure","speed":1.15}` changes speed mid-session. The live docs give the accepted range
+  as `0.5` to `1.5` in `0.05` steps. The `api` skill's generated reference still lists seven values from
+  `0.85` to `1.15`. The range has changed once already, so confirm it on the client-messages page
+  before hard-coding values. Errors: `SPEED_OUT_OF_RANGE`, `SPEED_INCREMENT_INVALID`,
+  `SPEED_NOT_SUPPORTED`.
+- `expressivity` runs `-2` (calm) to `2` (animated), default `0`. It is beta, fixed per connection, and
+  only `0` is validated for production.
+- The socket emits raw `linear16` (default), `mulaw`, or `alaw`. Batch-only parameters (`container`,
+  `bit_rate`, `callback`, `callback_method`, `priority`) and any unknown parameter fail the connection.
+- Idle sessions close after 60 seconds (`NET-0004`). Send a WebSocket Ping between quiet turns.
+- Batch: `POST https://api.deepgram.com/v2/speak?model=flux-haley-en` with `{"text": "..."}` returns one
+  audio response, `mp3` by default, and accepts `opus`, `flac`, `aac`, `container`, `bit_rate`.
+- SDKs: the Python, JavaScript, and Java SDKs ship a `speak.v2` client. Other languages use the
+  WebSocket directly.
+
+## Voices
+
+- Aura: `aura-2-{voice}-{lang}` in English, Spanish, German, French, Dutch, Italian, and Japanese, plus
+  twelve Aura-1 English voices named `aura-{voice}-en`. Catalog: https://developers.deepgram.com/docs/tts-models
+- Flux TTS: `flux-{voice}-en`, English only, in American, British, Irish, Australian, Indian,
+  Singaporean, and Filipino accents. Featured voices include `flux-haley-en`, `flux-alexis-en`, and
+  `flux-kit-en`. Catalog: https://developers.deepgram.com/docs/flux-tts/voices
+
+## Pricing
+
+Text-to-speech is billed per 1,000 characters of input text, for Flux TTS, Aura-2, and Aura-1 alike.
+Rates differ by model and plan and change over time. Read them at https://deepgram.com/pricing; do not
+quote figures from memory.
+
+## Common mistakes
+
+1. Wrong auth scheme. API keys go in `Authorization: Token <key>`. `Bearer` is only for the short-lived
+   JWT from `POST https://api.deepgram.com/v1/auth/grant`. A key sent with `Bearer` returns 401.
+2. Misreading a 403. The body `{"err_code":"INSUFFICIENT_PERMISSIONS","err_msg":"Project does not have
+   access to the requested model."}` is documented for a model the project cannot use, and a live test on
+   2026-09-03 returned the same body for a misspelled model name. Before asking for access, check the
+   name against the catalogs above and against `GET https://api.deepgram.com/v1/models`, whose `tts`
+   list shows the models your key can use.
+3. Parsing audio as JSON. Success bodies are bytes on both endpoints. Branch on status first.
+4. Crossing the families. An Aura voice on `/v2/speak` and a Flux voice on `/v1/speak` both fail, and
+   `/v2/speak` also rejects a missing `model`.
+5. Asking a WebSocket for `mp3`. Streaming is raw audio on both endpoints. Use REST for compressed output.
+6. Dropping the space between LLM generations on Flux TTS. `Speak` texts are concatenated verbatim, so
+   `"Hello world."` then `"How are you?"` becomes `"Hello world.How are you?"`. Insert a space when you
+   stitch a reply, a tool result, and another reply. SSML is stripped with an `INPUT_MARKUP_STRIPPED`
+   warning; send plain text.
+7. Pointing a Voice Agent at api.deepgram.com. The Voice Agent API lives at `wss://agent.deepgram.com`
+   and picks the TTS family from `agent.speak.provider.version`: `v2` for Flux TTS, `v1` for Aura.
+   Omitting `agent.speak` gives Flux TTS with `flux-kit-en`.
+8. Using Aura `speed` on a German, French, Dutch, Italian, or Japanese voice. Aura-2 speed control
+   covers English and Spanish only.
+
+## Use a different skill when
+
+- You need every parameter, enum, or message schema: `api` skill, file `references/speak.md`.
+- You need a docs page you cannot name: `docs` skill.
+- You want a runnable app: `starters` skill. Features are `text-to-speech` (Aura REST),
+  `live-text-to-speech` (Aura WebSocket), and `flux-tts` (node, flask, fastapi, django, java only).
+- You want a snippet under 50 lines: `recipes` skill. Recipes cover Aura on `/v1/speak` only; there
+  are no Flux TTS recipes yet.
+- You are wiring a third-party platform: `examples` skill (Aura today). For Twilio with Flux TTS,
+  follow https://developers.deepgram.com/docs/twilio-and-deepgram-tts.
+- You want the docs inside your coding tool: `setup-mcp` skill.
+- You want idiomatic code in one language: the `deepgram-{js,python,java,go,rust,dotnet}-text-to-speech`
+  skills from the SDK repositories (`npx skills add deepgram/deepgram-python-sdk`, and so on). Only the
+  Python, JavaScript, and Java SDKs expose `speak.v2` for Flux TTS.
+- You want Deepgram to run speech-to-text, the LLM, and TTS in one connection: `voice-agent` skill and
+  `deepgram-{lang}-voice-agent`.
+- You are transcribing rather than synthesizing: `speech-to-text` skill. Note that "Flux" names both a
+  speech-to-text product on `/v2/listen` and this text-to-speech product on `/v2/speak`.
+
+## Sources
+
+All pages fetched September 2026 as Markdown (append `.md` to any URL); index at https://developers.deepgram.com/llms.txt.
+
+- Aura: https://developers.deepgram.com/docs/text-to-speech https://developers.deepgram.com/docs/streaming-text-to-speech https://developers.deepgram.com/docs/tts-models https://developers.deepgram.com/docs/tts-voice-controls https://developers.deepgram.com/docs/tts-encoding https://developers.deepgram.com/docs/tts-media-output-settings https://developers.deepgram.com/docs/tts-ws-flush https://developers.deepgram.com/docs/tts-ws-clear
+- Flux TTS: https://developers.deepgram.com/docs/flux-tts/overview https://developers.deepgram.com/docs/flux-tts/quickstart https://developers.deepgram.com/docs/flux-tts/batch https://developers.deepgram.com/docs/flux-tts/batch-vs-streaming https://developers.deepgram.com/docs/flux-tts/voices https://developers.deepgram.com/docs/flux-tts/client-messages https://developers.deepgram.com/docs/flux-tts/server-messages https://developers.deepgram.com/docs/flux-tts/interrupt-handling https://developers.deepgram.com/docs/flux-tts/migrating https://developers.deepgram.com/docs/flux-tts/voice-agent https://developers.deepgram.com/docs/flux-tts/template-apps https://developers.deepgram.com/docs/tts-expressivity
+- API reference: https://developers.deepgram.com/reference/text-to-speech/speak-request https://developers.deepgram.com/reference/text-to-speech/speak-streaming https://developers.deepgram.com/reference/text-to-speech/speak-flux https://developers.deepgram.com/reference/speak/v-2/audio/generate https://developers.deepgram.com/reference/manage/models/list
+- Auth, errors, agent, pricing: https://developers.deepgram.com/reference/authentication https://developers.deepgram.com/reference/auth/tokens/grant https://developers.deepgram.com/docs/errors https://developers.deepgram.com/docs/voice-agent-tts-models https://developers.deepgram.com/reference/voice-agent/voice-agent https://deepgram.com/pricing

--- a/skills/voice-agent/SKILL.md
+++ b/skills/voice-agent/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: voice-agent
+description: >
+  Build a real-time voice agent on Deepgram's Voice Agent API: one WebSocket at
+  wss://agent.deepgram.com/v1/agent/converse that runs speech-to-text, a language model
+  (Deepgram-hosted or your own endpoint), and text-to-speech, with barge-in, mid-call
+  updates, and function calling that your own client executes. Use when someone says
+  "voice agent", "voice bot", "speech-to-speech", "talk to an AI on the phone",
+  "agent.deepgram.com", "Settings message", "FunctionCallRequest", "barge-in",
+  "Twilio voice agent", or asks whether to build on Deepgram directly or through
+  LiveKit Agents, Pipecat, Vapi, or Retell. Routes to the api, docs, starters, recipes,
+  examples, and per-language SDK skills for the full reference.
+---
+
+# Deepgram Voice Agent API
+
+Audio in, audio out, one connection. Deepgram runs the listen, think, and speak stages and the turn-taking between them. Your code streams the user's audio, plays the agent's audio, and answers function calls. [1][2]
+
+## Decide first: the Voice Agent API or an orchestrator
+
+Both paths are supported; Deepgram publishes guides for LiveKit Agents and Pipecat. Choose by who should own the pipeline.
+
+| Build on the Voice Agent API when | Use an orchestrator (LiveKit Agents, Pipecat, Vapi, Retell) with Deepgram STT and TTS underneath when |
+|---|---|
+| You want one WebSocket and no pipeline code. End-of-turn detection, barge-in, and the handoffs between stages are handled in-process. [2] | You already run that framework, or you need its transport (for example WebRTC rooms) and client libraries. |
+| A Deepgram-managed LLM (OpenAI, Anthropic, Google, NVIDIA) billed through your Deepgram account is fine, or you point `think.endpoint` at your own OpenAI-compatible endpoint. [6] | You need per-stage control the agent does not expose: your own LLM loop, a TTS vendor Deepgram does not proxy, custom voice activity detection, or your own turn logic. |
+| Your tools can run in your client or behind an HTTP endpoint you own (`FunctionCallRequest` / `FunctionCallResponse`). [9][10] | Your tools live inside the framework's agent runtime. |
+
+For the orchestrator path, load the `examples` skill (LiveKit, Pipecat) and the SDK `conversational-stt` and `text-to-speech` skills. Deepgram's Pipecat guide runs Flux STT and Flux TTS (`flux-alexis-en`) underneath; the LiveKit guide starts on `nova-3` and `aura-2-thalia-en` and shows `flux-general-en` and `flux-alexis-en` as the Flux swap. [14] The rest of this skill covers the Voice Agent API path.
+
+## First request
+
+The agent host is `agent.deepgram.com`; `api.deepgram.com` serves the other APIs. This call lists the LLM models Deepgram can run for you; check a `think.provider.model` value here before it goes into `Settings`. [6]
+
+```bash
+curl -s https://agent.deepgram.com/v1/agent/settings/think/models \
+  -H "Authorization: Token $DEEPGRAM_API_KEY"
+# 200 {"models":[{"id":"gpt-4o-mini","name":"...","provider":"open_ai"}, ...]}
+```
+
+This catalog endpoint answers without a key; the key is first checked at the WebSocket handshake below.
+
+Then open the WebSocket to `wss://agent.deepgram.com/v1/agent/converse` with the same `Authorization: Token <key>` header. The URL takes no query parameters; all configuration goes in the `Settings` message. [1][3] EU and AU regional hosts are listed on the Build a Voice Agent page. [1] A browser cannot set headers on a WebSocket, so mint a short-lived JWT server-side with `POST https://api.deepgram.com/v1/auth/grant` (needs a Member-scope key; 30-second TTL by default, up to 3,600 with `ttl_seconds`) and pass the token as the `Sec-WebSocket-Protocol` value on the handshake, the way the Browser Agent SDK does. The token only has to be valid at the handshake. [4]
+
+## Connect, configure, stream
+
+1. Connect. Wait for `{"type":"Welcome","request_id":"..."}`. Send nothing before it. [5]
+2. Send one `Settings` message. Wait for `{"type":"SettingsApplied"}`. Send no audio and no inject messages before it. [5]
+3. Stream raw audio as binary WebSocket frames. Play the binary frames you receive. JSON events arrive as text frames on the same socket, so branch on frame type first. [5]
+
+```json
+{
+  "type": "Settings",
+  "audio": {
+    "input":  { "encoding": "linear16", "sample_rate": 16000 },
+    "output": { "encoding": "linear16", "sample_rate": 24000, "container": "none" }
+  },
+  "agent": {
+    "listen": { "provider": { "type": "deepgram", "version": "v2", "model": "flux-general-en" } },
+    "think": {
+      "provider": { "type": "open_ai", "model": "gpt-4o-mini", "temperature": 0.7 },
+      "prompt": "You are a concise phone assistant. Reply in one or two sentences.",
+      "functions": [ { "name": "get_weather", "description": "Current weather for a location",
+        "parameters": { "type": "object", "properties": { "location": { "type": "string" } }, "required": ["location"] } } ]
+    },
+    "speak": { "provider": { "type": "deepgram", "version": "v2", "model": "flux-alexis-en" } },
+    "greeting": "Hi, how can I help?"
+  }
+}
+```
+
+Field notes, from the configure and model pages [3][6][7][8]:
+
+- `listen`: Flux (`flux-general-en`, or `flux-general-multi` with `language_hints`) requires `"version": "v2"` and gives model-integrated end-of-turn detection. Nova (`nova-3`) uses `v1`, the default, and adds `smart_format` and `language`. Drop `version` with a Flux model and the agent falls back to the v1 endpoint, where `flux-general-en` is not a valid model. [7][20]
+- `think`: `provider.type` is `open_ai`, `anthropic`, `google`, or `nvidia` (managed; `endpoint` optional) or `groq` or `aws_bedrock` (`endpoint` required). Bring your own LLM by keeping `type: open_ai` and setting `endpoint.url` to any OpenAI Chat Completions-compatible URL, with `endpoint.headers` for its auth. Pass an array of providers to get an ordered fallback chain. Managed-LLM prompts are limited to 25,000 characters. [6]
+- `speak`: `"version": "v2"` selects Flux TTS (`flux-{voice}-{language}`); `v1`, the default when you name a provider, selects Aura (`aura-2-thalia-en`). Omit `agent.speak` entirely and you get Flux TTS with `flux-kit-en`. Flux TTS streams raw audio only: `encoding` must be `linear16`, `mulaw`, or `alaw`, `container` must be `none`, and `mp3` or `wav` returns `INVALID_SETTINGS`. Third-party TTS (`open_ai`, `eleven_labs`, `cartesia`, `aws_polly`) takes an `endpoint`, except Deepgram-managed Cartesia, which needs none. [8]
+- `agent.context.messages` replays earlier turns as `{"type":"History","role":"user","content":"..."}` so a new session continues an old one. [3]
+
+## Message lifecycle
+
+| From | Message | What to do |
+|---|---|---|
+| server | `Welcome` | Send `Settings`. [5] |
+| server | `SettingsApplied` | Start streaming audio. [5] |
+| server | `UserStartedSpeaking` | Barge-in. Stop playback now and discard every buffered agent audio frame. [11] |
+| server | `ConversationText` (`role` is `user` or `assistant`, `content`) | Show the transcript. [11] |
+| server | `AgentThinking` (`content`) | Optional status. The LLM is working, possibly choosing a function. [11] |
+| server | `FunctionCallRequest` | See the next section. [9] |
+| server | `AgentStartedSpeaking` (`total_latency`, `tts_latency`, `ttt_latency`) | The reply's audio is starting; the fields are seconds. [12] |
+| server | binary frames | Agent audio. Queue it for playback. [5] |
+| server | `AgentAudioDone` | Last chunk sent. The user may still be hearing buffered audio, so treat your output queue as the end-of-playback signal rather than this event. [11] |
+| server | `Error` / `Warning` (`code`, `description`) | `Error` ends the session; reconnect. `Warning` is informational. [13] |
+| client | `KeepAlive` | Only while you are not sending audio, one every 8 seconds. It does not extend the 2-hour session limit. [15] |
+
+Mid-call updates, each acknowledged by a matching `*Updated` event [16]:
+
+- `UpdatePrompt` `{"type":"UpdatePrompt","prompt":"..."}` adds to the current prompt; it does not replace it. Ack: `PromptUpdated`. [16]
+- `UpdateSpeak` `{"type":"UpdateSpeak","speak":{"provider":{...}}}` changes the voice. With Flux TTS the new voice starts on the next turn. Ack: `SpeakUpdated`. [16]
+- `UpdateListen` adjusts Flux end-of-turn thresholds, keyterms, and language hints. `UpdateThink` replaces the whole think block, functions included. Acks: `ListenUpdated`, `ThinkUpdated`. `ForceEndTurn` ends the user's turn now and needs a Flux (`v2`) listen provider. [16][17]
+- `InjectAgentMessage` `{"type":"InjectAgentMessage","message":"...","behavior":"default"}` makes the agent speak. `default` and `queue` are refused with `InjectionRefused` while the user is speaking; `queue` waits behind the agent's own turn; only `interrupt` is never refused. `InjectUserMessage` `{"type":"InjectUserMessage","content":"..."}` sends typed user text. [18][5]
+
+## Function calling: your client runs the call
+
+Define functions under `agent.think.functions` with `name`, `description`, and JSON-schema `parameters`. Leave out `endpoint` and the function is client-side. Add `endpoint` (`url`, `method`, `headers`) and Deepgram calls that HTTP endpoint itself. [3][12][19]
+
+The server sends one `FunctionCallRequest` with a `functions` array. Each item has `id`, `name`, `arguments` (a JSON string; parse it), `client_side`, and sometimes `thought_signature`. [9]
+
+- `client_side: true`: run the function, then send `{"type":"FunctionCallResponse","id":"<same id>","name":"get_weather","content":"<result text or JSON string>"}`. Pass `thought_signature` back unchanged when present. The agent speaks once your response arrives. [9][10]
+- `client_side: false`: the server ran it (an `endpoint` function). No client action; the server's own `FunctionCallResponse` is informational. [10]
+
+During a slow call, send `InjectAgentMessage` with `behavior: "queue"` ("One moment while I look that up"). [18] A call to a name you did not define ends the session with `NON_EXISTENT_FUNCTION_CALLED`. [13]
+
+## Telephony
+
+Twilio Media Streams: answer the call with TwiML `<Connect><Stream url="wss://your-host/media"/>`. It is bidirectional; `<Start><Stream>` cannot carry the agent's voice. Set both `audio.input` and `audio.output` to `mulaw` at `8000` with `container: none`, base64-decode each Twilio `media` payload and send it as a binary frame, base64-encode agent audio back into Twilio `media` frames, and on `UserStartedSpeaking` send Twilio `{"event":"clear","streamSid":...}` so it drops its buffered audio. Working bridges: `deepgram-devs/twilio-voice-agent` (Python SDK) and `deepgram-devs/sts-twilio` (raw WebSocket). [20] The examples repository, which the `examples` skill routes to, has the Node version, `021-twilio-voice-agent-node`. [21]
+
+Other platforms with Deepgram guides: Genesys Cloud CX (Audio Connector), Amazon Connect, AudioCodes LiveHub, plus inbound and outbound reference apps. [2][22] The documentation index lists no SIP guide; bring SIP calls through one of those platforms or a gateway that yields a WebSocket audio stream. [23]
+
+## Pricing
+
+The Voice Agent API is billed per minute of WebSocket connection time, and a Deepgram-managed LLM is billed through the same account. Speech-to-text alone is per minute of audio; text-to-speech alone is per 1,000 characters. Rates change; read <https://deepgram.com/pricing>. [1][24]
+
+## Common mistakes
+
+1. `Authorization: Bearer <api key>` returns 401. API keys use the `Token` scheme. `Bearer` is only for JWTs from `/v1/auth/grant`. [4][25]
+2. REST calls sent to `agent.deepgram.com`, or the agent socket opened on `api.deepgram.com`. Only `/v1/agent/*` lives on the agent host; the published OpenAPI lists the agent host first, so generated clients need an explicit base URL. [1][26]
+3. Any message before `Welcome`, audio before `SettingsApplied`, or a second `Settings`: `NON_SETTINGS_MESSAGE_BEFORE_SETTINGS` or `SETTINGS_ALREADY_APPLIED`. One `Settings` per connection; reconnect to change it. [5][13]
+4. A model name that does not exist. On `/v1/listen` and `/v1/speak` it returns the same 403 body as a model your project cannot use, `{"err_code":"INSUFFICIENT_PERMISSIONS",...}` (verified live 2026-09-03). Check `GET https://api.deepgram.com/v1/models` first. There is no model named `nova-3-conversational`; conversational STT is `flux-general-en` with `version: v2`. [27][7]
+5. A declared audio format that does not match the bytes: `USER_AUDIO_FORMAT`. Encoding and sample rate in `Settings` must match what you stream. [13]
+6. Parsing every frame as JSON. Agent audio is binary. The same applies to `/v1/speak` and `/v2/speak`, whose success body is audio, so branch on frame type or HTTP status before parsing. [5][26]
+7. Not stopping playback on `UserStartedSpeaking`. Deepgram already stopped generating; the leftover in your buffer (or Twilio's) is what talks over the caller. [11][20]
+8. Expecting `UpdatePrompt` to replace the prompt. It appends. Use `UpdateThink` to replace. [16][17]
+9. Leaning on `KeepAlive` past two hours. Sessions close at 2:00:00 after a warning at 1:55; start a new session and pass the old turns in `agent.context`. [13][15]
+
+## Use a different skill when
+
+- You need the full message schema (every `Settings` field, every client and server message): `api` skill, `references/agent.md`, or the AsyncAPI-derived reference. [12]
+- You want a runnable app to clone: `starters` skill, feature `voice-agent` (node, bun, deno, flask, django, fastapi, go, java, csharp, ruby, php, cpp, rust). [28]
+- You want a minimal snippet for one feature (`connect`, `custom-llm`, `custom-tts`, `function-calling`): `recipes` skill. [29]
+- You are wiring a third-party platform (Twilio, LiveKit, Pipecat, Vonage, SignalWire, CrewAI, OpenAI Agents SDK): `examples` skill. [21]
+- You want language-idiomatic code: `deepgram-js-voice-agent`, `deepgram-python-voice-agent`, `deepgram-java-voice-agent`, `deepgram-rust-voice-agent`, `deepgram-dotnet-voice-agent`, or `deepgram-go-voice-agent`. The Go SDK v3 ships an agent WebSocket client under `pkg/client/agent/v1/websocket`, even though its open issue #321 (filed automatically in March 2026) still asks for one; check the package before relying on it, and the raw protocol above always works. [30]
+- You only need transcription with turn detection, or only synthesis: the SDK `conversational-stt`, `speech-to-text`, or `text-to-speech` skills.
+- You want to find a docs page: `docs` skill. You want the MCP server: `setup-mcp` skill.
+
+## Sources
+
+1. https://developers.deepgram.com/docs/build-a-voice-agent (endpoint, regional hosts, usage by connection time)
+2. https://developers.deepgram.com/docs/voice-agent-architecture
+3. https://developers.deepgram.com/docs/configure-voice-agent
+4. https://developers.deepgram.com/guides/fundamentals/token-based-authentication and https://developers.deepgram.com/reference/auth/tokens/grant
+5. https://developers.deepgram.com/docs/voice-agent-message-flow
+6. https://developers.deepgram.com/docs/voice-agent-llm-models
+7. https://developers.deepgram.com/docs/voice-agent-stt-models
+8. https://developers.deepgram.com/docs/voice-agent-tts-models
+9. https://developers.deepgram.com/docs/voice-agent-function-call-request
+10. https://developers.deepgram.com/docs/voice-agent-function-call-response
+11. Server event pages: https://developers.deepgram.com/docs/voice-agent-user-started-speaking, https://developers.deepgram.com/docs/voice-agent-conversation-text, https://developers.deepgram.com/docs/voice-agent-agent-thinking, https://developers.deepgram.com/docs/voice-agent-agent-audio-done
+12. https://developers.deepgram.com/reference/voice-agent/voice-agent (AsyncAPI; `AgentStartedSpeaking` fields)
+13. https://developers.deepgram.com/docs/voice-agent-errors-warnings
+14. https://developers.deepgram.com/docs/livekit-integration and https://developers.deepgram.com/docs/pipecat-integration
+15. https://developers.deepgram.com/docs/agent-keep-alive
+16. https://developers.deepgram.com/docs/voice-agent-acknowledgements, https://developers.deepgram.com/docs/voice-agent-update-listen, https://developers.deepgram.com/docs/voice-agent-update-prompt, https://developers.deepgram.com/docs/voice-agent-update-speak
+17. https://developers.deepgram.com/docs/voice-agent-update-think and https://developers.deepgram.com/docs/voice-agent-force-end-turn
+18. https://developers.deepgram.com/docs/voice-agent-inject-agent-message and https://developers.deepgram.com/docs/voice-agent-inject-user-message
+19. https://developers.deepgram.com/docs/build-a-function-call
+20. https://developers.deepgram.com/docs/twilio-and-deepgram-voice-agent
+21. https://github.com/deepgram/examples (directories `021-twilio-voice-agent-node`, `030-livekit-agents-python`, `080-pipecat-voice-pipeline-python`)
+22. https://developers.deepgram.com/docs/inbound-telephony-agent and https://developers.deepgram.com/docs/genesys-and-deepgram-voice-agent
+23. https://developers.deepgram.com/llms.txt (full docs index; no SIP entry as of 2026-09-03)
+24. https://deepgram.com/pricing (Voice Agent "calculated based on websocket connection time"; TTS "per 1,000 characters of input text")
+25. https://developers.deepgram.com/reference/authentication
+26. https://developers.deepgram.com/openapi.yaml (top-level `servers` lists `https://agent.deepgram.com` before `https://api.deepgram.com`, checked 2026-09-03) and the `api` skill's "Common Mistakes" section
+27. https://developers.deepgram.com/reference/manage/models/list (live catalog checked 2026-09-03: no `nova-3-conversational`)
+28. https://developers.deepgram.com/docs/voice-agent-template-apps and https://github.com/deepgram-starters (the docs page omits Java; `java-voice-agent` exists in the org, checked 2026-09-03)
+29. https://github.com/deepgram/recipes/blob/main/COVERAGE.md
+30. https://github.com/deepgram/deepgram-go-sdk (`.agents/skills/deepgram-go-voice-agent`, module `github.com/deepgram/deepgram-go-sdk/v3`) and https://github.com/deepgram/deepgram-go-sdk/issues/321


### PR DESCRIPTION
## What this adds

Three capability-named entry skills: `speech-to-text`, `text-to-speech`, and `voice-agent`.

skills.sh, the registry that installs skills into Claude Code, Cursor, GitHub Copilot, Codex, and other coding agents, matches and ranks skills by name from install telemetry. Our current skill names (`api`, `docs`, `starters`, `recipes`, `examples`, `setup-mcp`) describe how this repository is organized rather than what a developer is trying to do, so the searches that carry buying intent ("speech-to-text", "text-to-speech", "voice agent") match competitors' skills and none of ours. A study of 16,893 coding-agent sessions published by Armature on September 3, 2026 recorded all three harnesses (Claude Code, Codex, Cursor) consulting installed skills during vendor selection, which is why the names matter.

Each new skill is a short, hand-written on-ramp (under 180 lines): the decision rule for that capability (which model family, which endpoint), one runnable curl request, the mistakes agents actually make, and routing into the existing skills (`api` for the full reference, `docs`, `starters`, `recipes`, `examples`) and into the per-language SDK skills. Nothing is duplicated from the generated reference, and no existing skill is renamed, so every published install command keeps working.

Also in this change:
- `README.md`: the three skills lead the skills table, the install section shows `npx skills add deepgram/skills --skill <name>` for each before the install-everything command, and the Claude Code slash-command list gains the three entries.
- `.claude-plugin/marketplace.json`: the three skills join the `deepgram` plugin, listed first.

## Facts and sources

Every URL in the three files was fetched and returned HTTP 200 at authoring time, and every endpoint path, model name, parameter, and WebSocket message name was checked against the Deepgram documentation page cited in that file's Sources list (the `.md` Markdown mirror of each page). Prices are not quoted anywhere; the skills point at deepgram.com/pricing and state the billing unit only.

## Relationship to #8

This branch is cut from `main`. #8 (the README dead-end fix, plus a new AGENTS.md) touches a different README section, so both merge cleanly in either order. Once #8 lands, AGENTS.md's layout table will say "six shipped skills" and should read nine; that is a one-word follow-up.

## Provenance

An AI coding agent (Claude, operated by Darren Apfel) wrote these skills as part of a developer-experience review, with a second agent verifying every URL and claim against the live documentation before this pull request was opened. Please review the copy with the usual scrutiny; the substance is the routing and the decision rules.
